### PR TITLE
Updates: Cleanup dashboard layout and CLI parameters, update benchmark suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build
+_artefacts
 data
 *.key
 *.pem

--- a/README.md
+++ b/README.md
@@ -106,11 +106,12 @@ A handshake is performed when a client connects to the server
 
 The following is sent as a request from the client to server **AND** the response from server to client
 
-| Field        | Type                     |
-| ------------ | ------------------------ |
-| version hash | `\n` delimited string    |
+| Field              | Type                     |
+| -------            | ------------------------ |
+| contents type hash | `\n` delimited string    |
 
+`contents hash type` is the hex-encoded hash of the **name** of the content type using `Store.Hash`.
 
-`V1` is the handshake version for the initial implementation. So if the hash for your store is using `BLAKE2B`,
-the `version hash` would be `BLAKE2B("V1")` - this is used as a basic sanity check to ensure the client
-and server have the same hash implementation
+For example, for a store with `string` contents and BLAKE2B hash the `contents type hash` is equal to `BLAKE2B("string")`
+
+This is used as a basic sanity check to ensure the client and server have the same hash and contents implementation

--- a/README.md
+++ b/README.md
@@ -106,9 +106,11 @@ A handshake is performed when a client connects to the server
 
 The following is sent as a request from the client to server **AND** the response from server to client
 
-| Field   | Type                     |
-| ------- | ------------------------ |
-| version | `\n` delimited string    |
+| Field        | Type                     |
+| ------------ | ------------------------ |
+| version hash | `\n` delimited string    |
 
 
-`V1` is the handshake version for the initial implementation
+`V1` is the handshake version for the initial implementation. So if the hash for your store is using `BLAKE2B`,
+the `version hash` would be `BLAKE2B("V1")` - this is used as a basic sanity check to ensure the client
+and server have the same hash implementation

--- a/bench/bench_common.ml
+++ b/bench/bench_common.ml
@@ -93,10 +93,10 @@ module Conf = struct
   let stable_hash = 256
 end
 
-let info () =
+let info (type a) (module Client : Irmin_client.S with type Info.t = a) () =
   let date = Int64.of_float (Unix.gettimeofday ()) in
   let author = Printf.sprintf "TESTS" in
-  Irmin.Info.v ~date ~author "commit "
+  Client.Info.init date ~author ~message:"commit "
 
 module FSHelper = struct
   let file f =

--- a/bench/dune
+++ b/bench/dune
@@ -19,18 +19,12 @@
 
 (library
  (name irmin_traces)
- (modules trace_common trace_definitions trace_collection)
+ (modules trace_common trace_definitions trace_collection trace_stat_summary
+   trace_stat_summary_conf trace_stat_summary_utils trace_stat_summary_pp)
  (preprocess
   (pps ppx_repr ppx_deriving.enum))
- (libraries
-  irmin-server irmin-client
-  unix
-  lwt
-  repr
-  ppx_repr
-  bentov
-  mtime
-  mtime.clock.os))
+ (libraries irmin irmin-pack unix lwt repr ppx_repr bentov mtime printbox
+   printbox.unicode mtime.clock.os))
 
 (executable
  (name main)
@@ -77,3 +71,4 @@
   mtime
   mtime.clock.os
   tezos-context-hash-irmin))
+

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -548,7 +548,7 @@ module Make_store_layered (C : Irmin_pack.Conf.S) = struct
   let create_repo config =
     let* client =
       Lwt.catch
-        (fun () -> Client.connect ~uri:config.uri ())
+        (fun () -> Client.connect ~uri:(Uri.of_string config.uri) ())
         (fun exc ->
           Logs.err (fun l -> l "Unable to connect: %s" config.uri);
           raise exc)
@@ -578,7 +578,7 @@ module Make_store_pack (C : Irmin_pack.Conf.S) = struct
   let create_repo config =
     let* client =
       Lwt.catch
-        (fun () -> Client.connect ~uri:config.uri ())
+        (fun () -> Client.connect ~uri:(Uri.of_string config.uri) ())
         (fun exc ->
           Logs.err (fun l -> l "Unable to connect: %s" config.uri);
           raise exc)
@@ -724,7 +724,7 @@ let run_server (module Conf : Irmin_pack.Conf.S) config =
       let cfg =
         Irmin_pack.config ~readonly:false ~fresh:true config.store_dir
       in
-      let* server = Server.v ~uri:config.uri cfg in
+      let* server = Server.v ~uri:(Uri.of_string config.uri) cfg in
       Server.serve ~stop server);
   wake
 

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -317,7 +317,7 @@ module Trace_replay (Client : Store) = struct
         (* in tezos commits call Tree.list first for the unshallow operation *)
         Client.Tree.list tree []
       in*)
-    let info () = Irmin.Info.v ~date ~author:"Tezos" message in
+    let info () = Client.Info.init ~author:"Tezos" ~message date in
     let* commit =
       Client.Commit.v repo ~info ~parents:parents_store tree
       >|= Error.unwrap "Commit.v"
@@ -464,6 +464,8 @@ module Benchmark = struct
 end
 
 module Bench_suite (Client : Store) = struct
+  let info = info (module Client)
+
   let init_commit repo =
     let empty = Client.Tree.empty repo in
     Client.Commit.v repo ~info ~parents:[] empty >|= Error.unwrap "Commit.v"

--- a/bench/trace_collection.ml
+++ b/bench/trace_collection.ml
@@ -16,18 +16,12 @@
 
 (** Trace file construction.
 
-    This file is also meant to be used from Tezos. OCaml version 4.09 and the
-    32bit architecture should be supported.
+    This file is meant to be used from Tezos. OCaml version 4.09 and the 32bit
+    architecture should be supported.
 
     A module [Make_replayable] has yet to be implemented. *)
 
-let ( >>= ) = Lwt.Infix.( >>= )
-
-let ( >|= ) = Lwt.Infix.( >|= )
-
-let ( let* ) = ( >>= )
-
-let ( let+ ) = ( >|= )
+open Lwt.Syntax
 
 (** Make state trace collector. *)
 module Make_stat (Store : Irmin.KV) = struct
@@ -143,7 +137,9 @@ module Make_stat (Store : Irmin.KV) = struct
         }
 
     let now () =
-      Mtime_clock.now () |> Mtime.to_uint64_ns |> Int64.to_float
+      Mtime_clock.now ()
+      |> Mtime.to_uint64_ns
+      |> Int64.to_float
       |> ( *. ) Mtime.ns_to_s
 
     let create store_path prev_nb_merge =
@@ -184,11 +180,8 @@ module Make_stat (Store : Irmin.KV) = struct
     }
 
   let flush { writer; _ } = Def.flush writer
-
   let close { writer; _ } = Def.close writer
-
   let remove { writer; _ } = Def.remove writer
-
   let short_op_begin t = t.t0 <- Mtime_clock.counter ()
 
   let short_op_end { t0; writer; _ } short_op =

--- a/bench/trace_common.ml
+++ b/bench/trace_common.ml
@@ -27,8 +27,8 @@
       - Row (row_t, _ bytes)
     v}
 
-    This file is also meant to be used from Tezos. OCaml version 4.09 and the
-    32bit architecture should be supported.
+    This file is meant to be used from Tezos. OCaml version 4.09 and the 32bit
+    architecture should be supported.
 
     {3 Example}
 
@@ -109,9 +109,7 @@ module Magic : sig
   type t
 
   val of_string : string -> t
-
   val to_string : t -> string
-
   val pp : Format.formatter -> t -> unit
 end = struct
   type t = string
@@ -122,7 +120,6 @@ end = struct
     s
 
   let to_string s = s
-
   let pp ppf s = Format.fprintf ppf "%s" (String.escaped s)
 end
 
@@ -147,7 +144,6 @@ module type File_format = sig
     val version : int
 
     type header [@@deriving repr]
-
     type row [@@deriving repr]
   end
 
@@ -198,13 +194,9 @@ end
     performance sensitive, the read operations are not. *)
 module Io (Ff : File_format) = struct
   let decode_i32 = Repr.(decode_bin int32 |> unstage)
-
   let encode_i32 = Repr.(encode_bin int32 |> unstage)
-
   let encode_lheader = Repr.(encode_bin Ff.Latest.header_t |> unstage)
-
   let encode_lrow = Repr.(encode_bin Ff.Latest.row_t |> unstage)
-
   let magic = Ff.magic
 
   let read_with_prefix_exn : (string -> int -> int * 'a) -> in_channel -> 'a =
@@ -283,7 +275,6 @@ module Io (Ff : File_format) = struct
     Buffer.clear buffer
 
   let flush { channel; _ } = flush channel
-
   let close { channel; _ } = close_out channel
 
   let remove { channel; path; _ } =

--- a/bench/trace_definitions.ml
+++ b/bench/trace_definitions.ml
@@ -16,8 +16,8 @@
 
 (** Traces file format definitions.
 
-    This file is also meant to be used from Tezos. OCaml version 4.09 and the
-    32bit architecture should be supported.
+    This file is meant to be used from Tezos. OCaml version 4.09 and the 32bit
+    architecture should be supported.
 
     {3 Traces Workflow}
 
@@ -65,15 +65,10 @@ module Replayable_trace = struct
     let version = 0
 
     type header = unit [@@deriving repr]
-
     type 'a scope = Forget of 'a | Keep of 'a [@@deriving repr]
-
     type key = string list [@@deriving repr]
-
     type hash = string [@@deriving repr]
-
     type message = string [@@deriving repr]
-
     type context_id = int64 [@@deriving repr]
 
     type add = {
@@ -140,7 +135,29 @@ end
 
 (** Trace of a tezos node run, or a replay run.
 
-    May summarised to a JSON file. *)
+    May be summarised to a JSON file.
+
+    {3 Implicitly Auto-Upgradable File Format}
+
+    The stat trace has these two properties:
+
+    - It supports extensions, in order to change or add new stats in the future.
+    - Old trace files from old versions are still readable.
+
+    There are multiple reasons for wanting compatibility with old versions:
+
+    - Because one of the goal of the benchmarks is to assess the evolution of
+      performances across distant versions of irmin, we need stability in order
+      to avoid recomputing everything every time.
+    - When those traces will be produced by Tezos nodes, we have no control over
+      the version of those traces.
+
+    For this system to work, the "decoding shape" of a version of the stat trace
+    shouldn't ever change (once fixed). The way the trace is built for a version
+    should be stable too.
+
+    To modify something in the definition or the collection: append a new
+    version. *)
 module Stat_trace = struct
   module V0 = struct
     type float32 = int32 [@@deriving repr]

--- a/bench/trace_stat_summary.ml
+++ b/bench/trace_stat_summary.ml
@@ -1,0 +1,880 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** Conversion of a [Stat_trace] to a summary that is both pretty-printable and
+    exportable to JSON.
+
+    The main type [t] here isn't versioned like a [Stat_trace.t] is.
+
+    Computing a summary may take a long time if the input [Stat_trace] is long.
+    Count ~1000 commits per second.
+
+    This file is NOT meant to be used from Tezos, as opposed to some other
+    "trace_*" files.
+
+    {3 Phases}
+
+    A stat trace can be chunked into {e blocks}. A {e blocks} is made of 2
+    phases, first the {e buildup} and then the {e commit}.
+
+    The duration of a {e buildup} can be split into 2 parts: 1. the time spend
+    in each operation and 2. the sum of the time spent between, before and after
+    all operations. The first being the {e seen buildup} and the second the
+    {e unseen buildup}.
+
+    The total duration of a block is the sum of the durations of the {e commit},
+    the {e seen buildup} and the {e unseen buildup}.
+
+    Caveat: There isn't a one to one correspondance between summary blocks and
+    Tezos' blocks. A Tezos block is associated to a commit, but a commit is not
+    necessarily associated to a Tezos block. There are ~50 more commits than
+    Tezos blocks up to the Edo protocol. *)
+
+module Def = Trace_definitions.Stat_trace
+module Conf = Trace_stat_summary_conf
+module Utils = Trace_stat_summary_utils
+module Vs = Utils.Variable_summary
+
+(* Section 1/4 - Type of a summary. *)
+
+type curve = Utils.curve [@@deriving repr]
+
+module Op = struct
+  module Key = struct
+    type t =
+      [ `Add
+      | `Remove
+      | `Find
+      | `Mem
+      | `Mem_tree
+      | `Checkout
+      | `Copy
+      | `Commit
+      | `Unseen ]
+    [@@deriving repr, enum]
+
+    let to_string v =
+      match String.split_on_char '"' (Irmin.Type.to_string t v) with
+      | [ ""; s; "" ] -> s |> String.lowercase_ascii
+      | _ -> failwith "Could not encode op name to json"
+
+    let of_string s =
+      let s = "\"" ^ String.capitalize_ascii s ^ "\"" in
+      match Irmin.Type.of_string t s with Ok v -> Ok v | Error _ as e -> e
+  end
+
+  module Val = struct
+    (* The [count] count curve for [commit] and [unseen] is trivialy equal to 1.
+       Almost for [checkout] too.
+
+       Since there are always, per block, 1 commit and 1 unseen (and 1 checkout,
+       except for the first block), the [count]
+    *)
+    type t = {
+      count : Vs.t;
+      cumu_count : Vs.t;
+      duration : Vs.t;
+      duration_log_scale : Vs.t;
+      cumu_duration : Vs.t;
+    }
+    [@@deriving repr]
+  end
+
+  module Map = Map.Make (struct
+    type t = Key.t
+
+    let compare = compare
+  end)
+
+  type map = Val.t Map.t
+
+  let map_t : map Irmin.Type.t =
+    let encode map =
+      Map.bindings map |> List.map (fun (k, v) -> (Key.to_string k, v))
+    in
+    let decode l =
+      let key_of_string k =
+        match Key.of_string k with
+        | Ok k -> k
+        | Error (`Msg msg) ->
+            Fmt.failwith "Could not convert string back to key: %s" msg
+      in
+      List.map (fun (k, v) -> (key_of_string k, v)) l
+      |> List.to_seq
+      |> Map.of_seq
+    in
+    Irmin.Type.(map (Json.assoc Val.t) decode encode)
+end
+
+module Watched_node = struct
+  module Key = struct
+    type t = Def.watched_node [@@deriving repr]
+
+    let to_string v =
+      match String.split_on_char '"' (Irmin.Type.to_string t v) with
+      | [ ""; s; "" ] -> s |> String.lowercase_ascii
+      | _ -> failwith "Could not encode op name to json"
+
+    let of_string s =
+      let s = "\"" ^ String.capitalize_ascii s ^ "\"" in
+      match Irmin.Type.of_string t s with Ok v -> Ok v | Error _ as e -> e
+  end
+
+  module Val = struct
+    type t = { value : Vs.t; diff_per_block : Vs.t } [@@deriving repr]
+  end
+
+  module Map = Map.Make (struct
+    type t = Key.t
+
+    let compare = compare
+  end)
+
+  type map = Val.t Map.t
+
+  let map_t : map Irmin.Type.t =
+    let encode map =
+      Map.bindings map |> List.map (fun (k, v) -> (Key.to_string k, v))
+    in
+    let decode l =
+      let key_of_string k =
+        match Key.of_string k with
+        | Ok k -> k
+        | Error (`Msg msg) ->
+            Fmt.failwith "Could not convert string back to key: %s" msg
+      in
+      List.map (fun (k, v) -> (key_of_string k, v)) l
+      |> List.to_seq
+      |> Map.of_seq
+    in
+    Irmin.Type.(map (Json.assoc Val.t) decode encode)
+end
+
+type linear_bag_stat = {
+  value : Vs.t;
+  diff_per_block : Vs.t;
+  diff_per_buildup : Vs.t;
+  diff_per_commit : Vs.t;
+}
+[@@deriving repr]
+(** Summary of an entry of [Def.bag_of_stat], recorded in header, before and
+    after each commit. *)
+
+type pack = {
+  finds : linear_bag_stat;
+  cache_misses : linear_bag_stat;
+  appended_hashes : linear_bag_stat;
+  appended_offsets : linear_bag_stat;
+}
+[@@deriving repr]
+
+type tree = {
+  contents_hash : linear_bag_stat;
+  contents_find : linear_bag_stat;
+  contents_add : linear_bag_stat;
+  node_hash : linear_bag_stat;
+  node_mem : linear_bag_stat;
+  node_add : linear_bag_stat;
+  node_find : linear_bag_stat;
+  node_val_v : linear_bag_stat;
+  node_val_find : linear_bag_stat;
+  node_val_list : linear_bag_stat;
+}
+[@@deriving repr]
+
+type index = {
+  bytes_read : linear_bag_stat;
+  nb_reads : linear_bag_stat;
+  bytes_written : linear_bag_stat;
+  nb_writes : linear_bag_stat;
+  nb_merge : linear_bag_stat;
+  merge_durations : float list;
+}
+[@@deriving repr]
+
+type gc = {
+  minor_words : linear_bag_stat;
+  promoted_words : linear_bag_stat;
+  major_words : linear_bag_stat;
+  minor_collections : linear_bag_stat;
+  major_collections : linear_bag_stat;
+  compactions : linear_bag_stat;
+  major_heap_bytes : linear_bag_stat;
+  major_heap_top_bytes : curve;
+}
+[@@deriving repr]
+
+type disk = {
+  index_data : linear_bag_stat;
+  index_log : linear_bag_stat;
+  index_log_async : linear_bag_stat;
+  store_dict : linear_bag_stat;
+  store_pack : linear_bag_stat;
+}
+[@@deriving repr]
+
+type store = { watched_nodes : Watched_node.map } [@@deriving repr]
+
+type t = {
+  summary_timeofday : float;
+  summary_hostname : string;
+  curves_sample_count : int;
+  moving_average_half_life_ratio : float;
+  (* Stats from [Def.header]. *)
+  config : Def.config;
+  hostname : string;
+  word_size : int;
+  timeofday : float;
+  timestamp_wall0 : float;
+  timestamp_cpu0 : float;
+  (* Stats derived from [Def.row]s. *)
+  elapsed_wall : float;
+  elapsed_wall_over_blocks : Utils.curve;
+  elapsed_cpu : float;
+  elapsed_cpu_over_blocks : Utils.curve;
+  op_count : int;
+  ops : Op.map;
+  block_count : int;
+  index : index;
+  pack : pack;
+  tree : tree;
+  gc : gc;
+  disk : disk;
+  store : store;
+}
+[@@deriving repr]
+
+(* Section 2/4 - Converters from stat_strace to element of summary. *)
+let create_vs block_count =
+  Vs.create_acc ~distribution_bin_count:Conf.histo_bin_count
+    ~out_sample_count:Conf.curves_sample_count
+    ~in_period_count:(block_count + 1) ~evolution_resampling_mode:`Next_neighbor
+
+let create_vs_exact block_count =
+  create_vs block_count ~evolution_smoothing:`None ~scale:`Linear
+
+let create_vs_smooth block_count =
+  let hlr = Conf.moving_average_half_life_ratio in
+  let rt = Conf.moving_average_relevance_threshold in
+  create_vs block_count ~evolution_smoothing:(`Ema (hlr, rt)) ~scale:`Linear
+
+let create_vs_smooth_log block_count =
+  let hlr = Conf.moving_average_half_life_ratio in
+  let rt = Conf.moving_average_relevance_threshold in
+  create_vs block_count ~evolution_smoothing:(`Ema (hlr, rt)) ~scale:`Log
+
+(** Accumulator for the [ops] field of [t]. *)
+module Ops_folder = struct
+  let ops = List.init (Op.Key.max + 1) (fun i -> Op.Key.of_enum i |> Option.get)
+
+  type op_acc = {
+    durations_in_block : float list;
+    sum_count : int;
+    sum_duration : float;
+    count : Vs.acc;
+    cumu_count : Vs.acc;
+    duration : Vs.acc;
+    duration_log_scale : Vs.acc;
+    cumu_duration : Vs.acc;
+  }
+
+  type acc = { per_op : op_acc Op.Map.t; timestamp_before : float }
+
+  let create timestamp_before block_count =
+    let acc0 =
+      let acc0_per_op =
+        let count = create_vs_smooth block_count in
+        let count = Vs.accumulate count [] in
+        let cumu_count = create_vs_exact block_count in
+        let cumu_count = Vs.accumulate cumu_count [ 0. ] in
+        let duration = create_vs_smooth block_count in
+        let duration = Vs.accumulate duration [] in
+        let duration_log_scale = create_vs_smooth_log block_count in
+        let duration_log_scale = Vs.accumulate duration_log_scale [] in
+        let cumu_duration = create_vs_exact block_count in
+        let cumu_duration = Vs.accumulate cumu_duration [ 0. ] in
+        {
+          durations_in_block = [];
+          sum_count = 0;
+          sum_duration = 0.;
+          count;
+          cumu_count;
+          duration;
+          duration_log_scale;
+          cumu_duration;
+        }
+      in
+      let per_op =
+        List.map (fun op -> (op, acc0_per_op)) ops
+        |> List.to_seq
+        |> Op.Map.of_seq
+      in
+      { per_op; timestamp_before }
+    in
+
+    let accumulate acc row =
+      let on_duration acc op d =
+        let acc' = Op.Map.find op acc.per_op in
+        let acc' =
+          {
+            acc' with
+            durations_in_block = d :: acc'.durations_in_block;
+            sum_count = acc'.sum_count + 1;
+            sum_duration = acc'.sum_duration +. d;
+          }
+        in
+        { acc with per_op = Op.Map.add op acc' acc.per_op }
+      in
+      let on_duration32 acc op d = on_duration acc op (Int32.float_of_bits d) in
+      let on_commit (c : Def.commit) acc =
+        let seen_duration =
+          Op.Map.fold
+            (fun _ { durations_in_block; _ } x ->
+              List.fold_left ( +. ) x durations_in_block)
+            acc.per_op 0.
+        in
+        let total_duration = c.after.timestamp_wall -. acc.timestamp_before in
+        let unseen_duration = total_duration -. seen_duration in
+        let acc = on_duration acc `Unseen unseen_duration in
+
+        let per_op =
+          Op.Map.map
+            (fun acc' ->
+              let xs = acc'.durations_in_block in
+              let lenxs = List.length xs |> float_of_int in
+              let count = Vs.accumulate acc'.count [ lenxs ] in
+              let cumu_count =
+                Vs.accumulate acc'.cumu_count [ acc'.sum_count |> float_of_int ]
+              in
+              let duration = Vs.accumulate acc'.duration xs in
+              let duration_log_scale = Vs.accumulate acc'.duration xs in
+              let cumu_duration =
+                Vs.accumulate acc'.cumu_duration [ acc'.sum_duration ]
+              in
+              {
+                acc' with
+                durations_in_block = [];
+                count;
+                cumu_count;
+                duration;
+                duration_log_scale;
+                cumu_duration;
+              })
+            acc.per_op
+        in
+        { per_op; timestamp_before = c.after.timestamp_wall }
+      in
+      match row with
+      | `Add d -> on_duration32 acc `Add d
+      | `Remove d -> on_duration32 acc `Remove d
+      | `Find d -> on_duration32 acc `Find d
+      | `Mem d -> on_duration32 acc `Mem d
+      | `Mem_tree d -> on_duration32 acc `Mem_tree d
+      | `Checkout d -> on_duration32 acc `Checkout d
+      | `Copy d -> on_duration32 acc `Copy d
+      | `Commit c -> on_duration32 acc `Commit c.Def.duration |> on_commit c
+    in
+    let finalise { per_op; _ } =
+      Op.Map.map
+        (fun acc ->
+          {
+            Op.Val.count = Vs.finalise acc.count;
+            cumu_count = Vs.finalise acc.cumu_count;
+            duration = Vs.finalise acc.duration;
+            duration_log_scale = Vs.finalise acc.duration_log_scale;
+            cumu_duration = Vs.finalise acc.cumu_duration;
+          })
+        per_op
+    in
+    Utils.Parallel_folders.folder acc0 accumulate finalise
+end
+
+(** Summary computation for statistics recorded in [Def.bag_of_stat].
+
+    Properties of such a variables:
+
+    - Is sampled before each commit operation.
+    - Is sampled after each commit operation.
+    - Is sampled in header.
+    - Is expected to grow linearly (or mostly, i.e. [disk.store_pack] with
+      layered store). This implies that the curves/histos are best viewed on a
+      linear scale - as opposed to a log scale. *)
+module Linear_bag_stat_folder = struct
+  type acc = {
+    value : Vs.acc;
+    diff_per_block : Vs.acc;
+    diff_per_buildup : Vs.acc;
+    diff_per_commit : Vs.acc;
+    prev_value : float;
+    value_of_bag : Def.bag_of_stats -> float;
+  }
+
+  let create_acc header block_count value_of_bag =
+    let value_in_header = value_of_bag header.Def.initial_stats in
+    let value = create_vs_exact block_count in
+    let value = Vs.accumulate value [ value_in_header ] in
+    let diff_per_block = create_vs_smooth block_count in
+    let diff_per_block = Vs.accumulate diff_per_block [] in
+    let diff_per_buildup = create_vs_smooth block_count in
+    let diff_per_buildup = Vs.accumulate diff_per_buildup [] in
+    let diff_per_commit = create_vs_smooth block_count in
+    let diff_per_commit = Vs.accumulate diff_per_commit [] in
+    {
+      value;
+      diff_per_block;
+      diff_per_buildup;
+      diff_per_commit;
+      prev_value = value_in_header;
+      value_of_bag;
+    }
+
+  let accumulate acc row =
+    match row with
+    | `Commit c ->
+        let va = acc.value_of_bag c.Def.before in
+        let vb = acc.value_of_bag c.Def.after in
+        let diff_block = vb -. acc.prev_value in
+        let diff_buildup = va -. acc.prev_value in
+        let diff_commit = vb -. va in
+        let value = Vs.accumulate acc.value [ vb ] in
+        let diff_per_block = Vs.accumulate acc.diff_per_block [ diff_block ] in
+        let diff_per_buildup =
+          Vs.accumulate acc.diff_per_buildup [ diff_buildup ]
+        in
+        let diff_per_commit =
+          Vs.accumulate acc.diff_per_commit [ diff_commit ]
+        in
+        {
+          acc with
+          value;
+          diff_per_block;
+          diff_per_buildup;
+          diff_per_commit;
+          prev_value = vb;
+        }
+    | _ -> acc
+
+  let finalise acc : linear_bag_stat =
+    {
+      value = Vs.finalise acc.value;
+      diff_per_block = Vs.finalise acc.diff_per_block;
+      diff_per_buildup = Vs.finalise acc.diff_per_buildup;
+      diff_per_commit = Vs.finalise acc.diff_per_commit;
+    }
+
+  let create header block_count value_of_bag =
+    let acc0 = create_acc header block_count value_of_bag in
+    Utils.Parallel_folders.folder acc0 accumulate finalise
+end
+
+(** Accumulator for the [store] field of [t]. *)
+module Store_watched_nodes_folder = struct
+  type acc_per_node = {
+    value : Vs.acc;
+    diff_per_block : Vs.acc;
+    prev_value : float;
+  }
+
+  type acc = acc_per_node list
+
+  let create_acc block_count =
+    let acc0_per_node =
+      let value = create_vs_exact block_count in
+      let value = Vs.accumulate value [] in
+      let diff_per_block = create_vs_smooth block_count in
+      let diff_per_block = Vs.accumulate diff_per_block [] in
+      { value; diff_per_block; prev_value = Float.nan }
+    in
+    List.map (Fun.const acc0_per_node) Def.watched_nodes
+
+  let accumulate acc row =
+    match row with
+    | `Commit c ->
+        let accumulate_per_node v acc =
+          let v = float_of_int v in
+          let diff_block = v -. acc.prev_value in
+          let value = Vs.accumulate acc.value [ v ] in
+          let diff_per_block =
+            Vs.accumulate acc.diff_per_block [ diff_block ]
+          in
+          { value; diff_per_block; prev_value = v }
+        in
+        List.map2 accumulate_per_node c.Def.store_after.watched_nodes_length acc
+    | _ -> acc
+
+  let finalise acc : Watched_node.map =
+    List.map2
+      (fun k acc ->
+        let v =
+          {
+            Watched_node.Val.value = Vs.finalise acc.value;
+            diff_per_block = Vs.finalise acc.diff_per_block;
+          }
+        in
+        (k, v))
+      Def.watched_nodes acc
+    |> List.to_seq
+    |> Watched_node.Map.of_seq
+
+  let create block_count =
+    let acc0 = create_acc block_count in
+    Utils.Parallel_folders.folder acc0 accumulate finalise
+end
+
+(** Build a resampled curve of [gc.top_heap_words] *)
+let major_heap_top_bytes_folder header block_count =
+  let ws = header.Def.word_size / 8 |> float_of_int in
+  let len0 = block_count + 1 in
+  let len1 = Conf.curves_sample_count in
+  let v0 = float_of_int header.Def.initial_stats.gc.top_heap_words *. ws in
+  let acc0 = Utils.Resample.create_acc `Next_neighbor ~len0 ~len1 ~v00:v0 in
+  let accumulate acc = function
+    | `Commit c ->
+        Utils.Resample.accumulate acc
+          (float_of_int c.Def.after.gc.top_heap_words *. ws)
+    | _ -> acc
+  in
+  let finalise = Utils.Resample.finalise in
+  Utils.Parallel_folders.folder acc0 accumulate finalise
+
+(** Build a resampled curve of timestamps. *)
+let elapsed_wall_over_blocks_folder header block_count =
+  let open Def in
+  let len0 = block_count + 1 in
+  let len1 = Conf.curves_sample_count in
+  let v0 = header.initial_stats.timestamp_wall in
+  let acc0 = Utils.Resample.create_acc `Interpolate ~len0 ~len1 ~v00:v0 in
+  let accumulate acc = function
+    | `Commit c -> Utils.Resample.accumulate acc c.after.timestamp_wall
+    | _ -> acc
+  in
+  let finalise acc =
+    Utils.Resample.finalise acc |> List.map (fun t -> t -. v0)
+  in
+  Utils.Parallel_folders.folder acc0 accumulate finalise
+
+(** Build a resampled curve of timestamps. *)
+let elapsed_cpu_over_blocks_folder header block_count =
+  let open Def in
+  let len0 = block_count + 1 in
+  let len1 = Conf.curves_sample_count in
+  let v0 = header.initial_stats.timestamp_cpu in
+  let acc0 = Utils.Resample.create_acc `Interpolate ~len0 ~len1 ~v00:v0 in
+  let accumulate acc = function
+    | `Commit c -> Utils.Resample.accumulate acc c.after.timestamp_cpu
+    | _ -> acc
+  in
+  let finalise acc =
+    Utils.Resample.finalise acc |> List.map (fun t -> t -. v0)
+  in
+  Utils.Parallel_folders.folder acc0 accumulate finalise
+
+(** Build a list of all the merge durations. *)
+let merge_durations_folder =
+  let acc0 = [] in
+  let accumulate l = function
+    | `Commit c ->
+        let l = List.rev_append c.Def.before.index.new_merge_durations l in
+        let l = List.rev_append c.Def.after.index.new_merge_durations l in
+        l
+    | _ -> l
+  in
+  let finalise = List.rev in
+  Utils.Parallel_folders.folder acc0 accumulate finalise
+
+(** Substract the first and the last timestamps and count the number of ops. *)
+let misc_stats_folder header =
+  let open Def in
+  let acc0 = (0., 0., 0) in
+  let accumulate (t, t', count) = function
+    | `Commit c -> (c.after.timestamp_wall, c.after.timestamp_cpu, count + 1)
+    | _ -> (t, t', count + 1)
+  in
+  let finalise (t, t', count) =
+    ( t -. header.initial_stats.timestamp_wall,
+      t' -. header.initial_stats.timestamp_cpu,
+      count )
+  in
+  Utils.Parallel_folders.folder acc0 accumulate finalise
+
+(* Section 3/4 - Converter from stat_strace to summary *)
+
+(** Fold over [row_seq] and produce the summary.
+
+    {3 Parallel Folders}
+
+    Almost all entries in [t] require to independently fold over the rows of the
+    stat trace, but we want:
+
+    - not to fully load the trace in memory,
+    - not to reread the trace from disk once for each entry,
+    - this current file to be verbose and simple,
+    - to have fun with GADTs and avoid mutability.
+
+    All the boilerplate is hidden behind [Utils.Parallel_folders], a
+    datastructure that holds all folder functions, takes care of feeding the
+    rows to those folders, and preseves the types.
+
+    In the code below, [pf0] is the initial parallel folder, before the first
+    accumulation. Each [|+ ...] statement declares a [acc, accumulate, finalise]
+    triplet, i.e. a folder.
+
+    [val acc : acc] is the initial empty accumulation of a folder.
+
+    [val accumulate : acc -> row -> acc] needs to be folded over all rows of the
+    stat trace. Calling [Parallel_folders.accumulate pf row] will feed [row] to
+    every folders.
+
+    [val finalise : acc -> v] has to be applied on the final [acc] of a folder
+    in order to produce the final value of that folder - which value is meant to
+    be stored in [Trace_stat_summary.t]. Calling [Parallel_folders.finalise pf]
+    will finalise all folders and pass their result to [construct]. *)
+let summarise' header block_count (row_seq : Def.row Seq.t) =
+  let lbs_folder_of_bag_getter value_of_bag =
+    Linear_bag_stat_folder.create header block_count value_of_bag
+  in
+
+  let pack_folder =
+    let construct finds cache_misses appended_hashes appended_offsets =
+      { finds; cache_misses; appended_hashes; appended_offsets }
+    in
+    let acc0 =
+      let open Utils.Parallel_folders in
+      let ofi = float_of_int in
+      open_ construct
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.finds)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.cache_misses)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.appended_hashes)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.pack.appended_offsets)
+      |> seal
+    in
+    Utils.Parallel_folders.folder acc0 Utils.Parallel_folders.accumulate
+      Utils.Parallel_folders.finalise
+  in
+
+  let tree_folder =
+    let construct contents_hash contents_find contents_add node_hash node_mem
+        node_add node_find node_val_v node_val_find node_val_list =
+      {
+        contents_hash;
+        contents_find;
+        contents_add;
+        node_hash;
+        node_mem;
+        node_add;
+        node_find;
+        node_val_v;
+        node_val_find;
+        node_val_list;
+      }
+    in
+    let acc0 =
+      let open Utils.Parallel_folders in
+      let ofi = float_of_int in
+      open_ construct
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.tree.contents_hash)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.tree.contents_find)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.tree.contents_add)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.tree.node_hash)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.tree.node_mem)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.tree.node_add)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.tree.node_find)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.tree.node_val_v)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.tree.node_val_find)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.tree.node_val_list)
+      |> seal
+    in
+    Utils.Parallel_folders.folder acc0 Utils.Parallel_folders.accumulate
+      Utils.Parallel_folders.finalise
+  in
+
+  let index_folder =
+    let construct bytes_read nb_reads bytes_written nb_writes nb_merge
+        merge_durations =
+      {
+        bytes_read;
+        nb_reads;
+        bytes_written;
+        nb_writes;
+        nb_merge;
+        merge_durations;
+      }
+    in
+    let acc0 =
+      let open Utils.Parallel_folders in
+      let ofi = float_of_int in
+      open_ construct
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.index.bytes_read)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.index.nb_reads)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.index.bytes_written)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.index.nb_writes)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.index.nb_merge)
+      |+ merge_durations_folder
+      |> seal
+    in
+    Utils.Parallel_folders.folder acc0 Utils.Parallel_folders.accumulate
+      Utils.Parallel_folders.finalise
+  in
+
+  let gc_folder =
+    let construct minor_words promoted_words major_words minor_collections
+        major_collections compactions major_heap_bytes major_heap_top_bytes =
+      {
+        minor_words;
+        promoted_words;
+        major_words;
+        minor_collections;
+        major_collections;
+        compactions;
+        major_heap_bytes;
+        major_heap_top_bytes;
+      }
+    in
+    let acc0 =
+      let open Utils.Parallel_folders in
+      let ofi = float_of_int in
+      let ws = header.Def.word_size / 8 |> float_of_int in
+      open_ construct
+      |+ lbs_folder_of_bag_getter (fun bag -> bag.Def.gc.minor_words)
+      |+ lbs_folder_of_bag_getter (fun bag -> bag.Def.gc.promoted_words)
+      |+ lbs_folder_of_bag_getter (fun bag -> bag.Def.gc.major_words)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.gc.minor_collections)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.gc.major_collections)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.gc.compactions)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi bag.Def.gc.heap_words *. ws)
+      |+ major_heap_top_bytes_folder header block_count
+      |> seal
+    in
+    Utils.Parallel_folders.folder acc0 Utils.Parallel_folders.accumulate
+      Utils.Parallel_folders.finalise
+  in
+
+  let disk_folder =
+    let construct index_data index_log index_log_async store_dict store_pack =
+      { index_data; index_log; index_log_async; store_dict; store_pack }
+    in
+    let acc0 =
+      let open Utils.Parallel_folders in
+      let ofi64 = Int64.to_float in
+      open_ construct
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi64 bag.Def.disk.index_data)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi64 bag.Def.disk.index_log)
+      |+ lbs_folder_of_bag_getter (fun bag ->
+             ofi64 bag.Def.disk.index_log_async)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi64 bag.Def.disk.store_dict)
+      |+ lbs_folder_of_bag_getter (fun bag -> ofi64 bag.Def.disk.store_pack)
+      |> seal
+    in
+    Utils.Parallel_folders.folder acc0 Utils.Parallel_folders.accumulate
+      Utils.Parallel_folders.finalise
+  in
+
+  let construct (elapsed_wall, elapsed_cpu, op_count) elapsed_wall_over_blocks
+      elapsed_cpu_over_blocks ops pack tree index gc disk watched_nodes =
+    {
+      summary_hostname = Unix.gethostname ();
+      summary_timeofday = Unix.gettimeofday ();
+      elapsed_wall;
+      elapsed_cpu;
+      op_count;
+      block_count;
+      curves_sample_count = Conf.curves_sample_count;
+      moving_average_half_life_ratio = Conf.moving_average_half_life_ratio;
+      config = header.config;
+      hostname = header.hostname;
+      word_size = header.word_size;
+      timeofday = header.timeofday;
+      timestamp_wall0 = header.initial_stats.timestamp_wall;
+      timestamp_cpu0 = header.initial_stats.timestamp_cpu;
+      elapsed_wall_over_blocks;
+      elapsed_cpu_over_blocks;
+      ops;
+      pack;
+      tree;
+      index;
+      gc;
+      disk;
+      store = { watched_nodes };
+    }
+  in
+
+  let pf0 =
+    let open Utils.Parallel_folders in
+    open_ construct
+    |+ misc_stats_folder header
+    |+ elapsed_wall_over_blocks_folder header block_count
+    |+ elapsed_cpu_over_blocks_folder header block_count
+    |+ Ops_folder.create header.initial_stats.timestamp_wall block_count
+    |+ pack_folder
+    |+ tree_folder
+    |+ index_folder
+    |+ gc_folder
+    |+ disk_folder
+    |+ Store_watched_nodes_folder.create block_count
+    |> seal
+  in
+  Seq.fold_left Utils.Parallel_folders.accumulate pf0 row_seq
+  |> Utils.Parallel_folders.finalise
+
+(** Turn a stat trace into a summary.
+
+    The number of blocks to consider may be provided in order to truncate the
+    summary. *)
+let summarise ?block_count trace_stat_path =
+  let block_count =
+    match block_count with
+    | Some block_count -> block_count
+    | None ->
+        (* The trace has to be iterated a first time in order to retrieve the
+         * number of blocks. This is needed to:
+         * - define the moving average momentum,
+         * - stop the row sequence immediately after the last commit. *)
+        Trace_definitions.Stat_trace.open_reader trace_stat_path
+        |> snd
+        |> Seq.fold_left
+             (fun count op ->
+               match op with `Commit _ -> count + 1 | _ -> count)
+             0
+  in
+  if block_count <= 0 then invalid_arg "Can't summarise an empty stat trace";
+  let header, row_seq =
+    Trace_definitions.Stat_trace.open_reader trace_stat_path
+  in
+  let row_seq =
+    let aux (seq, commit_count) =
+      if commit_count >= block_count then None
+      else
+        match seq () with
+        | Seq.Nil ->
+            failwith
+              "summarise reached the end of the stat trace before \
+               'block_count' commits were seen"
+        | Seq.Cons ((`Commit _ as op), seq) -> Some (op, (seq, commit_count + 1))
+        | Seq.Cons (op, seq) -> Some (op, (seq, commit_count))
+    in
+    Seq.unfold aux (row_seq, 0)
+  in
+  summarise' header block_count row_seq
+
+(* Section 4/4 - Conversion from summary to json file *)
+
+let save_to_json v path =
+  let j = Fmt.strf "%a\n" (Irmin.Type.pp_json t) v in
+  let chan = open_out path in
+  output_string chan j;
+  Logs.app (fun l -> l "Summary saved to %s" path);
+  close_out chan;
+  Unix.chmod path 0o444

--- a/bench/trace_stat_summary_conf.ml
+++ b/bench/trace_stat_summary_conf.ml
@@ -1,0 +1,42 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** Summary configuration.
+
+    This file is NOT meant to be used from Tezos, as opposed to some other
+    "trace_*" files. *)
+
+let histo_bin_count = 16
+let curves_sample_count = 201
+
+(** Parameter to control the width of the moving average window.
+
+    This width is expressed as a fraction of the width of the final plot images,
+    (i.e. the number of played blocks). This implies that the amount of
+    smoothing remains visually the same, no matter [curves_sample_count] and the
+    number of blocks in the stat trace.
+
+    Justification of the current value:
+
+    The 2nd commit of the full replay trace is a massive one, it contains ~1000x
+    more operations than an average one, it takes ~10 half lives to fully get
+    rid of it from the EMAs. With [moving_average_half_life_ratio = 1. /. 80.],
+    that 2nd commit will only poluate [1 / 8] of the width of the smoothed
+    curves. *)
+let moving_average_half_life_ratio = 1. /. 80.
+
+(** See [Exponential_moving_average] *)
+let moving_average_relevance_threshold = 0.999

--- a/bench/trace_stat_summary_pp.ml
+++ b/bench/trace_stat_summary_pp.ml
@@ -1,0 +1,537 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** Pretty printing of one or more summaries.
+
+    This file is NOT meant to be used from Tezos, as opposed to some other
+    "trace_*" files.
+
+    This file contains A LOT of uninteresting boilerplate in order to build the
+    pretty-printable table. Doing this using pandas-like multi-level dataframes
+    would make the thing much more simpler. *)
+
+open Trace_stat_summary
+module Utils = Trace_stat_summary_utils
+module Summary = Trace_stat_summary
+
+module Pb = struct
+  include PrintBox
+
+  let () = PrintBox_unicode.setup ()
+
+  (* Some utilities to work with lists instead of array *)
+
+  let transpose_matrix l =
+    l
+    |> List.map Array.of_list
+    |> Array.of_list
+    |> PrintBox.transpose
+    |> Array.to_list
+    |> List.map Array.to_list
+
+  let matrix_to_text m = List.map (List.map PrintBox.text) m
+  let align_matrix where = List.map (List.map (PrintBox.align ~h:where ~v:`Top))
+
+  (** Dirty trick to only have vertical bars, and not the horizontal ones *)
+  let matrix_with_column_spacers =
+    let rec interleave sep = function
+      | ([ _ ] | []) as l -> l
+      | hd :: tl -> hd :: sep :: interleave sep tl
+    in
+    List.map (interleave (PrintBox.text " | "))
+end
+
+type summary = Summary.t
+
+type scalar_type = [ `R | `S | `P ]
+(** Real, Seconds, Percent *)
+
+type summary_floor =
+  [ `Spacer | `Data of scalar_type * string * (string * curve) list ]
+(** A [summary_floor] of tag [`Data] contains all the data necessary in order to
+    print a bunch of rows, 1 per summary, all displaying the same summary entry. *)
+
+let summary_config_entries =
+  [
+    `Hostname;
+    `Word_size;
+    `Timeofday;
+    `Inode_config;
+    `Store_type;
+    `Replay_path_conversion;
+  ]
+
+let name_of_summary_config_entry = function
+  | `Hostname -> "Hostname"
+  | `Word_size -> "Word Size"
+  | `Timeofday -> "Start Time"
+  | `Inode_config -> "Inode Config"
+  | `Store_type -> "Store Type"
+  | `Replay_path_conversion -> "Path Conversion"
+
+let cell_of_summary_config (s : summary) = function
+  | `Hostname -> s.hostname
+  | `Word_size -> Printf.sprintf "%d bits" s.word_size
+  | `Timeofday ->
+      let open Unix in
+      let t = gmtime s.timeofday in
+      Printf.sprintf "%04d/%02d/%02d %02d:%02d:%02d (GMT)" (1900 + t.tm_year)
+        (t.tm_mon + 1) t.tm_mday t.tm_hour t.tm_min t.tm_sec
+  | `Inode_config ->
+      let a, b, c = s.config.inode_config in
+      Printf.sprintf "mls:%d bf:%d sh:%d" a b c
+  | `Store_type -> (
+      match s.config.store_type with
+      | `Pack -> "pack"
+      | `Pack_layered -> "pack-layered")
+  | `Replay_path_conversion -> (
+      match s.config.setup with
+      | `Play _ -> "n/a"
+      | `Replay s -> (
+          match s.path_conversion with
+          | `None -> "none"
+          | `V1 -> "v1"
+          | `V0_and_v1 -> "v0+v1"
+          | `V0 -> "v0"))
+
+let box_of_summaries_config summary_names (summaries : summary list) =
+  let row0 =
+    if List.length summary_names = 1 then [] else [ "" :: summary_names ]
+  in
+  let rows =
+    List.map
+      (fun e ->
+        let n = name_of_summary_config_entry e in
+        let l = List.map (fun s -> cell_of_summary_config s e) summaries in
+        n :: l)
+      summary_config_entries
+  in
+  row0 @ rows |> Pb.matrix_to_text
+
+let sum_curves curves =
+  curves
+  |> Pb.transpose_matrix
+  |> List.map
+       (List.fold_left
+          (fun acc v -> if Float.is_nan v then acc else acc +. v)
+          0.)
+
+let div_curves a b = List.map2 ( /. ) a b
+let mul_curves a b = List.map2 ( *. ) a b
+
+let all_9_ops =
+  [ `Add; `Remove; `Find; `Mem; `Mem_tree; `Checkout; `Copy; `Commit; `Unseen ]
+
+let all_8_ops =
+  [ `Add; `Remove; `Find; `Mem; `Mem_tree; `Checkout; `Copy; `Commit ]
+
+let all_buildup_seen_ops =
+  [ `Add; `Remove; `Find; `Mem; `Mem_tree; `Checkout; `Copy ]
+
+let all_buildup_ro_ops = [ `Find; `Mem; `Mem_tree ]
+let all_buildup_rw_ops = [ `Add; `Remove; `Copy ]
+
+let floors_of_summaries : string list -> summary list -> summary_floor list =
+ fun summary_names summaries ->
+  (* Step 1/3 - Prepare the "/data/..." directories floors *)
+  let floor_per_node : summary_floor list =
+    List.map
+      (fun key ->
+        let path = List.assoc key Def.path_per_watched_node in
+        let name = Printf.sprintf "%s *S" path in
+        let curves =
+          List.map
+            (fun s ->
+              (Summary.Watched_node.Map.find key s.store.watched_nodes).value
+                .evolution)
+            summaries
+        in
+        let l = List.combine summary_names curves in
+        `Data (`R, name, l))
+      Def.watched_nodes
+  in
+
+  (* Step 2/3 - Prepare the functions to build all the simple floors *)
+  let zip : (summary -> curve) -> (string * curve) list =
+   fun curve_of_summary ->
+    List.map2
+      (fun sname s -> (sname, curve_of_summary s))
+      summary_names summaries
+  in
+  let zip_per_block_to_per_sec : (summary -> curve) -> (string * curve) list =
+    let sec_per_block =
+      List.map
+        (fun s ->
+          all_9_ops
+          |> List.map (fun op ->
+                 mul_curves Summary.(Op.Map.find op s.ops).duration.evolution
+                   Summary.(Op.Map.find op s.ops).count.evolution)
+          |> sum_curves)
+        summaries
+    in
+    fun curve_of_summary ->
+      List.map2
+        (fun (sname, sec_per_block) s ->
+          (sname, div_curves (curve_of_summary s) sec_per_block))
+        (List.combine summary_names sec_per_block)
+        summaries
+  in
+
+  let v : string -> (summary -> Summary.linear_bag_stat) -> summary_floor =
+   fun stat_name lbs_of_summary ->
+    let curves = zip (fun s -> (lbs_of_summary s).value.evolution) in
+    `Data (`R, stat_name, curves)
+  in
+  let pb : string -> (summary -> Summary.linear_bag_stat) -> summary_floor =
+   fun stat_name lbs_of_summary ->
+    let curves = zip (fun s -> (lbs_of_summary s).diff_per_block.evolution) in
+    `Data (`R, stat_name, curves)
+  in
+  let ps : string -> (summary -> Summary.linear_bag_stat) -> summary_floor =
+   fun stat_name lbs_of_summary ->
+    let curves =
+      zip_per_block_to_per_sec (fun s ->
+          (lbs_of_summary s).diff_per_block.evolution)
+    in
+    `Data (`R, stat_name, curves)
+  in
+
+  let op_count : string -> Op.Key.t -> summary_floor =
+   fun name op ->
+    let curves =
+      zip (fun s -> Summary.(Op.Map.find op s.ops).count.evolution)
+    in
+    `Data (`R, name, curves)
+  in
+  let op_duration : string -> Op.Key.t -> summary_floor =
+   fun name op ->
+    let curves =
+      zip (fun s -> Summary.(Op.Map.find op s.ops).duration.evolution)
+    in
+    `Data (`S, name, curves)
+  in
+  let op_every_sec : string -> Op.Key.t -> summary_floor =
+   fun name op ->
+    let curves =
+      zip_per_block_to_per_sec (fun s ->
+          Summary.(Op.Map.find op s.ops).count.evolution)
+    in
+    `Data (`R, name, curves)
+  in
+
+  let seen_duration =
+    zip (fun s ->
+        all_buildup_seen_ops
+        |> List.map (fun op ->
+               mul_curves Summary.(Op.Map.find op s.ops).duration.evolution
+                 Summary.(Op.Map.find op s.ops).count.evolution)
+        |> sum_curves)
+  in
+  let all_ops_cumu_count =
+    zip (fun s ->
+        all_8_ops
+        |> List.map (fun op ->
+               Summary.(Op.Map.find op s.ops).cumu_count.evolution)
+        |> sum_curves)
+  in
+  let ro_ops_per_sec =
+    zip_per_block_to_per_sec (fun s ->
+        all_buildup_ro_ops
+        |> List.map (fun op -> Summary.(Op.Map.find op s.ops).count.evolution)
+        |> sum_curves)
+  in
+  let rw_ops_per_sec =
+    zip_per_block_to_per_sec (fun s ->
+        all_buildup_rw_ops
+        |> List.map (fun op -> Summary.(Op.Map.find op s.ops).count.evolution)
+        |> sum_curves)
+  in
+  let sum_op_durations_per_block =
+    zip (fun s ->
+        all_9_ops
+        |> List.map (fun op ->
+               mul_curves Summary.(Op.Map.find op s.ops).duration.evolution
+                 Summary.(Op.Map.find op s.ops).count.evolution)
+        |> sum_curves)
+  in
+
+  (* Step 3/3 - Build the final list of floors *)
+  [
+    `Spacer;
+    `Data (`S, "Wall time elapsed *C", zip (fun s -> s.elapsed_wall_over_blocks));
+    `Data (`S, "CPU time elapsed *C", zip (fun s -> s.elapsed_cpu_over_blocks));
+    (* ops counts *)
+    `Spacer;
+    `Data (`R, "Ops count *C", all_ops_cumu_count);
+    `Data (`R, "Read only ops per sec *LA", ro_ops_per_sec);
+    `Data (`R, "Read write ops per sec *LA", rw_ops_per_sec);
+    (* <op> every sec *)
+    `Spacer;
+    op_every_sec "Commit every sec *LA" `Commit;
+    op_every_sec "Add every sec *LA" `Add;
+    op_every_sec "Remove every sec *LA" `Remove;
+    op_every_sec "Find every sec *LA" `Find;
+    op_every_sec "Mem every sec *LA" `Mem;
+    op_every_sec "Mem_tree every sec *LA" `Mem_tree;
+    op_every_sec "Copy every sec *LA" `Copy;
+    (* <op> per block *)
+    `Spacer;
+    op_count "Add count per block *LA" `Add;
+    op_count "Remove count per block *LA" `Remove;
+    op_count "Find count per block *LA" `Find;
+    op_count "Mem count per block *LA" `Mem;
+    op_count "Mem_tree count per block *LA" `Mem_tree;
+    op_count "Copy count per block *LA" `Copy;
+    (* <phase> duration *)
+    `Spacer;
+    `Data (`S, "Block duration *LA", sum_op_durations_per_block);
+    `Data (`S, "Buildup seen duration *LA", seen_duration);
+    op_duration "Buildup unseen duration *LA" `Unseen;
+    op_duration "Commit duration *LA" `Commit;
+    `Spacer;
+    (* <op> duration *)
+    op_duration "Add duration *LA" `Add;
+    op_duration "Remove duration *LA" `Remove;
+    op_duration "Find duration *LA" `Find;
+    op_duration "Mem duration *LA" `Mem;
+    op_duration "Mem_tree duration *LA" `Mem_tree;
+    op_duration "Copy duration *LA" `Copy;
+    op_duration "Checkout duration *LA" `Checkout;
+    (* derived from bag_of_stat *)
+    `Spacer;
+    pb "pack.finds per block *LA" (fun s -> s.pack.finds);
+    pb "pack.cache_misses per block *LA" (fun s -> s.pack.cache_misses);
+    pb "pack.appended_hashes per block *LA" (fun s -> s.pack.appended_hashes);
+    pb "pack.appended_offsets per block *LA" (fun s -> s.pack.appended_offsets);
+    `Spacer;
+    pb "tree.contents_hash per block *LA" (fun s -> s.tree.contents_hash);
+    pb "tree.contents_find per block *LA" (fun s -> s.tree.contents_find);
+    pb "tree.contents_add per block *LA" (fun s -> s.tree.contents_add);
+    pb "tree.node_hash per block *LA" (fun s -> s.tree.node_hash);
+    pb "tree.node_mem per block *LA" (fun s -> s.tree.node_mem);
+    pb "tree.node_add per block *LA" (fun s -> s.tree.node_add);
+    pb "tree.node_find per block *LA" (fun s -> s.tree.node_find);
+    pb "tree.node_val_v per block *LA" (fun s -> s.tree.node_val_v);
+    pb "tree.node_val_find per block *LA" (fun s -> s.tree.node_val_find);
+    pb "tree.node_val_list per block *LA" (fun s -> s.tree.node_val_list);
+    `Spacer;
+    v "index.bytes_read *C" (fun s -> s.index.bytes_read);
+    pb "index.bytes_read per block *LA" (fun s -> s.index.bytes_read);
+    ps "index.bytes_read per sec *LA" (fun s -> s.index.bytes_read);
+    v "index.nb_reads *C" (fun s -> s.index.nb_reads);
+    pb "index.nb_reads per block *LA" (fun s -> s.index.nb_reads);
+    ps "index.nb_reads per sec *LA" (fun s -> s.index.nb_reads);
+    v "index.bytes_written *C" (fun s -> s.index.bytes_written);
+    pb "index.bytes_written per block *LA" (fun s -> s.index.bytes_written);
+    ps "index.bytes_written per sec *LA" (fun s -> s.index.bytes_written);
+    v "index.nb_writes *C" (fun s -> s.index.nb_writes);
+    pb "index.nb_writes per block *LA" (fun s -> s.index.nb_writes);
+    ps "index.nb_writes per sec *LA" (fun s -> s.index.nb_writes);
+    v "index.nb_merge *C" (fun s -> s.index.nb_merge);
+    `Spacer;
+    v "gc.minor_words allocated *C" (fun s -> s.gc.minor_words);
+    pb "gc.minor_words allocated per block *LA" (fun s -> s.gc.minor_words);
+    ps "gc.minor_words allocated per sec *LA" (fun s -> s.gc.minor_words);
+    v "gc.promoted_words *C" (fun s -> s.gc.promoted_words);
+    v "gc.major_words allocated *C" (fun s -> s.gc.major_words);
+    pb "gc.major_words allocated per block *LA" (fun s -> s.gc.major_words);
+    ps "gc.major_words allocated per sec *LA" (fun s -> s.gc.major_words);
+    v "gc.minor_collections *C" (fun s -> s.gc.minor_collections);
+    pb "gc.minor_collections per block *LA" (fun s -> s.gc.minor_collections);
+    ps "gc.minor_collections per sec *LA" (fun s -> s.gc.minor_collections);
+    v "gc.major_collections *C" (fun s -> s.gc.major_collections);
+    pb "gc.major_collections per block *LA" (fun s -> s.gc.major_collections);
+    ps "gc.major_collections per sec *LA" (fun s -> s.gc.major_collections);
+    v "gc.compactions *C" (fun s -> s.gc.compactions);
+    `Data
+      ( `R,
+        "gc.major heap bytes top *C",
+        zip (fun s -> s.gc.major_heap_top_bytes) );
+    v "gc.major heap bytes *LA" (fun s -> s.gc.major_heap_bytes);
+    `Spacer;
+    v "index_data bytes *S" (fun s -> s.disk.index_data);
+    pb "index_data bytes per block *LA" (fun s -> s.disk.index_data);
+    ps "index_data bytes per sec *LA" (fun s -> s.disk.index_data);
+    v "store_pack bytes *S" (fun s -> s.disk.store_pack);
+    pb "store_pack bytes per block *LA" (fun s -> s.disk.store_pack);
+    ps "store_pack bytes per sec *LA" (fun s -> s.disk.store_pack);
+    v "index_log bytes *S" (fun s -> s.disk.index_log);
+    v "index_log_async *S" (fun s -> s.disk.index_log_async);
+    v "store_dict bytes *S" (fun s -> s.disk.store_dict);
+    `Spacer;
+  ]
+  @ floor_per_node
+
+let resample_curves_of_floor sample_count = function
+  | `Data (a, b, names_and_curves) ->
+      let names, curves = List.split names_and_curves in
+      let curves =
+        List.map
+          (fun curve ->
+            Utils.Resample.resample_vector `Next_neighbor curve sample_count)
+          curves
+      in
+      `Data (a, b, List.combine names curves)
+  | `Spacer -> `Spacer
+
+let matrix_of_data_floor (`Data (scalar_type, floor_name, names_and_curves)) =
+  let only_one_summary = List.length names_and_curves = 1 in
+  let _, curves = List.split names_and_curves in
+  let pp_real = Utils.create_pp_real (List.concat curves) in
+  let pp_seconds = Utils.create_pp_seconds (List.concat curves) in
+  let curve0 = List.hd curves in
+  let box_of_scalar row_idx col_idx (v0, v) =
+    let ratio = v /. v0 in
+    let show_percent =
+      if only_one_summary then
+        (* Percents are only needed for comparisons between summaries. *)
+        `No
+      else if col_idx = 0 then
+        (* The first columns is usually full of NaNs, showing percents there
+           is a waste of space. *)
+        `No
+      else if Float.is_finite ratio = false then
+        (* Nan and infinite percents are ugly. *)
+        `Shadow
+      else if row_idx = 0 then
+        (* The first row of a floor is always 100%, it is prettier without
+           displaying it. *)
+        `Shadow
+      else `Yes
+    in
+    (match (scalar_type, show_percent) with
+    | `R, `Yes -> Fmt.str "%a %a" pp_real v Utils.pp_percent ratio
+    | `R, `Shadow -> Fmt.str "%a     " pp_real v
+    | `R, `No -> Fmt.str "%a" pp_real v
+    | `S, `Yes -> Fmt.str "%a %a" pp_seconds v Utils.pp_percent ratio
+    | `S, `Shadow -> Fmt.str "%a     " pp_seconds v
+    | `S, `No -> Fmt.str "%a" pp_seconds v
+    | `P, `Yes -> Fmt.str "%.0f%%  %a" (v *. 100.) Utils.pp_percent ratio
+    | `P, `Shadow -> Fmt.str "%.0f%%     " (v *. 100.)
+    | `P, `No -> Fmt.str "%.0f%%" (v *. 100.))
+    |> Pb.text
+    |> Pb.align ~h:`Right ~v:`Top
+  in
+  let rows =
+    List.mapi
+      (fun row_idx (summary_name, curve) ->
+        let a = Pb.text (if row_idx = 0 then floor_name else "") in
+        let b = if only_one_summary then [] else [ Pb.text summary_name ] in
+        let c = List.mapi (box_of_scalar row_idx) (List.combine curve0 curve) in
+        a :: b @ c)
+      names_and_curves
+  in
+  rows
+
+let matrix_of_floor col_count = function
+  | `Spacer -> [ List.init col_count (Fun.const "") ] |> Pb.matrix_to_text
+  | `Data _ as floor -> matrix_of_data_floor floor
+
+let unsafe_pp sample_count ppf summary_names (summaries : Summary.t list) =
+  let block_count =
+    let l = List.map (fun s -> s.block_count) summaries in
+    let v = List.hd l in
+    if List.exists (fun v' -> v' <> v) l then
+      failwith "Can't pp together summaries with a different `block_count`";
+    v
+  in
+  let moving_average_half_life_ratio =
+    let l = List.map (fun s -> s.moving_average_half_life_ratio) summaries in
+    let v = List.hd l in
+    if List.exists (fun v' -> v' <> v) l then
+      failwith
+        "Can't pp together summaries with a different \
+         `moving_average_half_life_ratio`";
+    v
+  in
+  let tbl0 =
+    box_of_summaries_config summary_names summaries
+    |> Pb.matrix_with_column_spacers
+    |> Pb.grid_l ~bars:false
+    |> PrintBox_text.to_string
+  in
+  let header_rows =
+    let only_one_summary = List.length summaries = 1 in
+    let s = List.hd summaries in
+    let played_count_curve =
+      List.init Conf.curves_sample_count (fun i ->
+          float_of_int i
+          /. float_of_int (Conf.curves_sample_count - 1)
+          *. float_of_int s.block_count)
+    in
+    let played_count_curve =
+      Utils.Resample.resample_vector `Next_neighbor played_count_curve
+        sample_count
+      |> Array.of_list
+    in
+    let header_cells_per_col_idx col_idx =
+      let played_count = played_count_curve.(col_idx) in
+      let progress_blocks = played_count /. float_of_int s.block_count in
+      let h0 =
+        if progress_blocks = 0. then "0 (before)"
+        else if progress_blocks = 1. then
+          Printf.sprintf "%.0f (end)" played_count
+        else if Float.is_integer played_count then
+          Printf.sprintf "%.0f" played_count
+        else Printf.sprintf "%.1f" played_count
+      in
+      let h1 = Printf.sprintf "%.0f%%" (progress_blocks *. 100.) in
+      [ h0; h1 ]
+    in
+    let col_a =
+      [ [ "Block played count *C"; "Blocks progress *C" ] ] |> Pb.matrix_to_text
+    in
+    let col_b =
+      (if only_one_summary then [] else [ [ ""; "" ] ])
+      |> Pb.matrix_to_text
+      |> Pb.align_matrix `Center
+    in
+    let cols_c =
+      List.init sample_count header_cells_per_col_idx
+      |> Pb.matrix_to_text
+      |> Pb.align_matrix `Center
+    in
+    col_a @ col_b @ cols_c |> Pb.transpose_matrix
+  in
+  let body_rows =
+    let col_count =
+      sample_count + 1 + if List.length summaries = 1 then 0 else 1
+    in
+    floors_of_summaries summary_names summaries
+    |> List.map (resample_curves_of_floor sample_count)
+    |> List.map (matrix_of_floor col_count)
+    |> List.concat
+  in
+  let tbl1 =
+    header_rows @ body_rows
+    |> Pb.matrix_with_column_spacers
+    |> Pb.grid_l ~bars:false
+    |> PrintBox_text.to_string
+  in
+  Format.fprintf ppf
+    "%s\n\n\
+     %s\n\n\
+     Types of curves:\n\
+    \  *C: Cumulative. No smoothing.\n\
+    \  *LA: Local Average. Smoothed using a weighted sum of the value in the\n\
+    \       block and the exponentially decayed values of the previous blocks.\n\
+    \       Every %.2f blocks, half of the past is forgotten.\n\
+    \  *S: Size. E.g. directory entries, file bytes. No smoothing." tbl0 tbl1
+    (moving_average_half_life_ratio *. float_of_int (block_count + 1))
+
+let pp sample_count ppf (summary_names, summaries) =
+  if List.length summaries = 0 then ()
+  else unsafe_pp sample_count ppf summary_names summaries

--- a/bench/trace_stat_summary_utils.ml
+++ b/bench/trace_stat_summary_utils.ml
@@ -1,0 +1,539 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+type histo = (float * int) list [@@deriving repr]
+type curve = float list [@@deriving repr]
+
+let snap_to_integer ~significant_digits v =
+  if significant_digits < 0 then
+    invalid_arg "significant_digits should be greater or equal to zero.";
+  if not @@ Float.is_finite v then v
+  else if Float.is_integer v then v
+  else
+    (* This scope is about choosing between [v] and [Float.round v]. *)
+    let significant_digits = float_of_int significant_digits in
+    let v' = Float.round v in
+    if v' = 0. then (* Do not snap numbers close to 0. *)
+      v
+    else
+      let round_distance = Float.abs (v -. v') in
+      assert (round_distance <= 0.5);
+      (* The smaller [round_distance], the greater [significant_digits']. *)
+      let significant_digits' = -.Float.log10 round_distance in
+      assert (significant_digits' > 0.);
+      if significant_digits' >= significant_digits then v' else v
+
+let pp_six_digits_with_spacer ppf v =
+  let s = Printf.sprintf "%.6f" v in
+  let len = String.length s in
+  let a = String.sub s 0 (len - 3) in
+  let b = String.sub s (len - 3) 3 in
+  Format.fprintf ppf "%s_%s" a b
+
+let create_pp_real ?(significant_digits = 7) examples =
+  let examples = List.map (snap_to_integer ~significant_digits) examples in
+  let all_integer =
+    List.for_all
+      (fun v -> Float.is_integer v || not (Float.is_finite v))
+      examples
+  in
+  let absmax =
+    List.fold_left
+      (fun acc v ->
+        if not @@ Float.is_finite acc then v
+        else if not @@ Float.is_finite v then acc
+        else Float.abs v |> max acc)
+      Float.neg_infinity examples
+  in
+  let finite_pp =
+    if absmax /. 1e12 >= 10. then fun ppf v ->
+      Format.fprintf ppf "%.3f T" (v /. 1e12)
+    else if absmax /. 1e9 >= 10. then fun ppf v ->
+      Format.fprintf ppf "%.3f G" (v /. 1e9)
+    else if absmax /. 1e6 >= 10. then fun ppf v ->
+      Format.fprintf ppf "%.3f M" (v /. 1e6)
+    else if absmax /. 1e3 >= 10. then fun ppf v ->
+      Format.fprintf ppf "%#d" (Float.round v |> int_of_float)
+    else if all_integer then fun ppf v ->
+      Format.fprintf ppf "%#d" (Float.round v |> int_of_float)
+    else if absmax /. 1. >= 10. then fun ppf v -> Format.fprintf ppf "%.3f" v
+    else if absmax /. 1e-3 >= 10. then pp_six_digits_with_spacer
+    else fun ppf v -> Format.fprintf ppf "%.3e" v
+  in
+  fun ppf v ->
+    if Float.is_nan v then Format.fprintf ppf "n/a"
+    else if Float.is_infinite v then Format.fprintf ppf "%f" v
+    else finite_pp ppf v
+
+let create_pp_seconds examples =
+  let absmax =
+    List.fold_left
+      (fun acc v ->
+        if not @@ Float.is_finite acc then v
+        else if not @@ Float.is_finite v then acc
+        else Float.abs v |> max acc)
+      Float.neg_infinity examples
+  in
+  let finite_pp =
+    if absmax >= 60. then fun ppf v -> Mtime.Span.pp_float_s ppf v
+    else if absmax < 100. *. 1e-12 then fun ppf v ->
+      Format.fprintf ppf "%.3e s" v
+    else if absmax < 100. *. 1e-9 then fun ppf v ->
+      Format.fprintf ppf "%.3f ns" (v *. 1e9)
+    else if absmax < 100. *. 1e-6 then fun ppf v ->
+      Format.fprintf ppf "%.3f \xc2\xb5s" (v *. 1e6)
+    else if absmax < 100. *. 1e-3 then fun ppf v ->
+      Format.fprintf ppf "%.3f ms" (v *. 1e3)
+    else fun ppf v -> Format.fprintf ppf "%.3f  s" v
+  in
+  fun ppf v ->
+    if Float.is_nan v then Format.fprintf ppf "n/a"
+    else if Float.is_infinite v then Format.fprintf ppf "%f" v
+    else finite_pp ppf v
+
+let pp_percent ppf v =
+  if not @@ Float.is_finite v then Format.fprintf ppf "%4f" v
+  else if v = 0. then Format.fprintf ppf "  0%%"
+  else if v < 10. /. 100. then Format.fprintf ppf "%3.1f%%" (v *. 100.)
+  else if v < 1000. /. 100. then Format.fprintf ppf "%3.0f%%" (v *. 100.)
+  else if v < 1000. then Format.fprintf ppf "%3.0fx" v
+  else if v < 9.5e9 then (
+    let long_repr = Printf.sprintf "%.0e" v in
+    assert (String.length long_repr = 5);
+    Format.fprintf ppf "%ce%cx" long_repr.[0] long_repr.[4])
+  else Format.fprintf ppf "++++"
+
+module Exponential_moving_average = struct
+  type t = {
+    momentum : float;
+    relevance_threshold : float;
+    opp_momentum : float;
+    hidden_state : float;
+    void_fraction : float;
+  }
+
+  let create ?(relevance_threshold = 1.) momentum =
+    if momentum < 0. || momentum >= 1. then invalid_arg "Wrong momentum";
+    if relevance_threshold < 0. || relevance_threshold > 1. then
+      invalid_arg "Wrong relevance_threshold";
+    {
+      momentum;
+      relevance_threshold;
+      opp_momentum = 1. -. momentum;
+      hidden_state = 0.;
+      void_fraction = 1.;
+    }
+
+  let from_half_life ?relevance_threshold hl =
+    if hl < 0. then invalid_arg "Wrong half life";
+    create ?relevance_threshold (if hl = 0. then 0. else log 0.5 /. hl |> exp)
+
+  let from_half_life_ratio ?relevance_threshold hl_ratio step_count =
+    if hl_ratio < 0. then invalid_arg "Wrong half life ratio";
+    if step_count < 0. then invalid_arg "Wront step count";
+    step_count *. hl_ratio |> from_half_life ?relevance_threshold
+
+  let momentum ema = ema.momentum
+  let hidden_state ema = ema.hidden_state
+  let void_fraction ema = ema.void_fraction
+  let is_relevant ema = ema.void_fraction < ema.relevance_threshold
+
+  let peek_exn ema =
+    if is_relevant ema then ema.hidden_state /. (1. -. ema.void_fraction)
+    else failwith "Can't peek an irrelevant EMA"
+
+  let peek_or_nan ema =
+    if is_relevant ema then ema.hidden_state /. (1. -. ema.void_fraction)
+    else Float.nan
+
+  let update ema sample =
+    let hidden_state =
+      (* The first term is the "forget" term, the second one is the "remember"
+         term. *)
+      (ema.momentum *. ema.hidden_state) +. (ema.opp_momentum *. sample)
+    in
+    let void_fraction =
+      (* [update] decreases the quantity of "void". *)
+      ema.momentum *. ema.void_fraction
+    in
+    { ema with hidden_state; void_fraction }
+
+  let update_batch ema sample sample_size =
+    if sample_size <= 0. then invalid_arg "Wrong sample_size";
+    let momentum = ema.momentum ** sample_size in
+    let opp_momentum = 1. -. momentum in
+    (* From this point, the code is identical to [update]. *)
+    let hidden_state =
+      (ema.hidden_state *. momentum) +. (sample *. opp_momentum)
+    in
+    let void_fraction = ema.void_fraction *. momentum in
+    { ema with hidden_state; void_fraction }
+
+  (** [peek ema] is equal to [forget ema |> peek]. Modulo floating point
+      imprecisions and relevance changes.
+
+      Proof:
+
+      {v
+         v0 = hs0 / (1 - vf0)
+         v1 = hs1 / (1 - vf1)
+         hs1 = mom * hs0
+         vf1 = mom * vf0 + (1 - mom)
+         hs0 / (1 - vf0) = hs1         / (1 -  vf1)
+         hs0 / (1 - vf0) = (mom * hs0) / (1 -  (mom * vf0 + (1 - mom)))
+         hs0 / (1 - vf0) = (mom * hs0) / (1 -  (mom * vf0 +  1 - mom))
+         hs0 / (1 - vf0) = (mom * hs0) / (1 + (-mom * vf0 -  1 + mom))
+         hs0 / (1 - vf0) = (mom * hs0) / (1 -   mom * vf0 -  1 + mom)
+         hs0 / (1 - vf0) = (mom * hs0) / (     -mom * vf0      + mom)
+         hs0 / (1 - vf0) = (hs0)       / (     -1   * vf0      + 1)
+         hs0 / (1 - vf0) = hs0 / (1 - vf0)
+         v0 = v1
+      v} *)
+  let forget ema =
+    let hidden_state = ema.momentum *. ema.hidden_state in
+    let void_fraction =
+      (* [forget] increases the quantity of "void".
+
+          Where [update] does: [ema.m * ema.vf + ema.opp_m * 0],
+                [forget] does: [ema.m * ema.vf + ema.opp_m * 1]. *)
+      (ema.momentum *. ema.void_fraction) +. ema.opp_momentum
+    in
+    { ema with hidden_state; void_fraction }
+
+  let forget_batch ema sample_size =
+    if sample_size <= 0. then invalid_arg "Wrong sample_size";
+    let momentum = ema.momentum ** sample_size in
+    let opp_momentum = 1. -. momentum in
+    (* From this point, the code is identical to [forget]. *)
+    let hidden_state = ema.hidden_state *. momentum in
+    let void_fraction = (ema.void_fraction *. momentum) +. opp_momentum in
+    { ema with hidden_state; void_fraction }
+
+  let map ?relevance_threshold momentum vec0 =
+    List.fold_left
+      (fun (ema, rev_result) v0 ->
+        let ema = update ema v0 in
+        let v1 = peek_or_nan ema in
+        (ema, v1 :: rev_result))
+      (create ?relevance_threshold momentum, [])
+      vec0
+    |> snd
+    |> List.rev
+end
+
+module Resample = struct
+  let should_sample ~i0 ~len0 ~i1 ~len1 =
+    assert (len0 >= 2);
+    assert (len1 >= 2);
+    assert (i0 < len0);
+    assert (i0 >= 0);
+    assert (i1 >= 0);
+    if i1 >= len1 then `Out_of_bounds
+    else
+      let i0 = float_of_int i0 in
+      let len0 = float_of_int len0 in
+      let i1 = float_of_int i1 in
+      let len1 = float_of_int len1 in
+      let progress0_left = (i0 -. 1.) /. (len0 -. 1.) in
+      let progress0_right = i0 /. (len0 -. 1.) in
+      let progress1 = i1 /. (len1 -. 1.) in
+      if progress1 <= progress0_left then `Before
+      else if progress1 <= progress0_right then (
+        let where_in_interval =
+          (progress1 -. progress0_left) /. (progress0_right -. progress0_left)
+        in
+        assert (where_in_interval > 0.);
+        assert (where_in_interval <= 1.);
+        `Inside where_in_interval)
+      else `After
+
+  type acc = {
+    mode : [ `Interpolate | `Next_neighbor ];
+    len0 : int;
+    len1 : int;
+    i0 : int;
+    i1 : int;
+    prev_v0 : float;
+    rev_samples : curve;
+  }
+
+  let create_acc mode ~len0 ~len1 ~v00 =
+    let mode = (mode :> [ `Interpolate | `Next_neighbor ]) in
+    if len0 < 2 then invalid_arg "Can't resample curves below 2 points";
+    if len1 < 2 then invalid_arg "Can't resample curves below 2 points";
+    { mode; len0; len1; i0 = 1; i1 = 1; prev_v0 = v00; rev_samples = [ v00 ] }
+
+  let accumulate ({ mode; len0; len1; i0; i1; prev_v0; rev_samples } as acc) v0
+      =
+    assert (i0 >= 1);
+    assert (i1 >= 1);
+    if i0 >= len0 then failwith "Accumulate called to much";
+    if i1 >= len1 then failwith "Accumulate called to much";
+    let rec aux i1 rev_samples =
+      match should_sample ~len1 ~i0 ~len0 ~i1 with
+      | `Inside where_inside ->
+          if i1 = len1 - 1 then (
+            assert (i0 = len0 - 1);
+            assert (where_inside = 1.));
+          let v1 =
+            match mode with
+            | `Next_neighbor -> v0
+            | `Interpolate -> prev_v0 +. (where_inside *. (v0 -. prev_v0))
+          in
+          aux (i1 + 1) (v1 :: rev_samples)
+      | `After -> (i1, rev_samples)
+      | `Before -> assert false
+      | `Out_of_bounds ->
+          assert (i0 = len0 - 1);
+          assert (i1 = len1);
+          (i1, rev_samples)
+    in
+    let i1, rev_samples = aux i1 rev_samples in
+    { acc with i0 = i0 + 1; i1; prev_v0 = v0; rev_samples }
+
+  let finalise { len1; rev_samples; _ } =
+    if List.length rev_samples <> len1 then failwith "Finalise called too soon";
+    List.rev rev_samples
+
+  let resample_vector mode vec0 len1 =
+    let len0 = List.length vec0 in
+    if len0 < 2 then invalid_arg "Can't resample curves below 2 points";
+    let v00, vec0 =
+      match vec0 with hd :: tl -> (hd, tl) | _ -> assert false
+    in
+    let acc = create_acc mode ~len0 ~len1 ~v00 in
+    List.fold_left accumulate acc vec0 |> finalise
+end
+
+module Variable_summary = struct
+  type t = {
+    max_value : float * int;
+    min_value : float * int;
+    mean : float;
+    distribution : histo;
+    evolution : curve;
+  }
+  [@@deriving repr]
+
+  type acc = {
+    (* Accumulators *)
+    max_value : float * int;
+    min_value : float * int;
+    sum_value : float;
+    value_count : int;
+    distribution : Bentov.histogram;
+    rev_evolution : curve;
+    ma : Exponential_moving_average.t;
+    next_in_idx : int;
+    next_out_idx : int;
+    (* Constants *)
+    in_period_count : int;
+    out_sample_count : int;
+    evolution_resampling_mode :
+      [ `Interpolate | `Prev_neighbor | `Next_neighbor ];
+    scale : [ `Linear | `Log ];
+  }
+
+  let create_acc ~evolution_smoothing ~evolution_resampling_mode
+      ~distribution_bin_count ~scale ~in_period_count ~out_sample_count =
+    if in_period_count < 2 then
+      invalid_arg "in_period_count should be greater than 1";
+    if out_sample_count < 2 then
+      invalid_arg "out_sample_count should be greater than 1";
+    {
+      max_value = (Float.nan, 0);
+      min_value = (Float.nan, 0);
+      sum_value = 0.;
+      value_count = 0;
+      distribution = Bentov.create distribution_bin_count;
+      rev_evolution = [];
+      ma =
+        (match evolution_smoothing with
+        | `None -> Exponential_moving_average.create 0.
+        | `Ema (half_life_ratio, relevance_threshold) ->
+            Exponential_moving_average.from_half_life_ratio ~relevance_threshold
+              half_life_ratio
+              (float_of_int in_period_count));
+      next_in_idx = 0;
+      next_out_idx = 0;
+      in_period_count;
+      out_sample_count;
+      evolution_resampling_mode;
+      scale;
+    }
+
+  let accumulate acc occurences_of_variable_in_period =
+    let xs = occurences_of_variable_in_period in
+    let xs = List.filter (fun v -> not (Float.is_nan v)) xs in
+    let i = acc.next_in_idx in
+    let sample_count = List.length xs |> float_of_int in
+    assert (i < acc.in_period_count);
+
+    let accumulate_in_sample (((topv, _) as top), ((botv, _) as bot), histo, ma)
+        v =
+      let top = if Float.is_nan topv || topv < v then (v, i) else top in
+      let bot = if Float.is_nan botv || botv > v then (v, i) else bot in
+      let v =
+        match acc.scale with
+        | `Linear -> v
+        | `Log ->
+            if Float.is_infinite v then v
+            else if v <= 0. then
+              failwith
+                "Input samples to a Variable_summary should be > 0. when \
+                 scale=`Log."
+            else Float.log v
+      in
+      let histo = Bentov.add v histo in
+      let ma =
+        Exponential_moving_average.update_batch ma v (1. /. sample_count)
+      in
+      (top, bot, histo, ma)
+    in
+    let max_value, min_value, distribution, ma =
+      List.fold_left accumulate_in_sample
+        (acc.max_value, acc.min_value, acc.distribution, acc.ma)
+        xs
+    in
+    let ma =
+      if sample_count = 0. then Exponential_moving_average.forget ma else ma
+    in
+    let rev_evolution, next_out_idx =
+      let rec aux rev_samples next_out_idx =
+        match
+          Resample.should_sample ~i0:i ~len0:acc.in_period_count
+            ~i1:next_out_idx ~len1:acc.out_sample_count
+        with
+        | `Before -> assert false
+        | `Inside where_in_block ->
+            let out_sample =
+              let v_after = Exponential_moving_average.peek_or_nan ma in
+              if where_in_block = 1. then v_after
+              else (
+                assert (where_in_block > 0.);
+                assert (next_out_idx > 0);
+                let v_before = Exponential_moving_average.peek_or_nan acc.ma in
+                match acc.evolution_resampling_mode with
+                | `Prev_neighbor -> v_before
+                | `Next_neighbor -> v_after
+                | `Interpolate ->
+                    v_before +. ((v_after -. v_before) *. where_in_block))
+            in
+            aux (out_sample :: rev_samples) (next_out_idx + 1)
+        | `After | `Out_of_bounds -> (rev_samples, next_out_idx)
+      in
+      aux acc.rev_evolution acc.next_out_idx
+    in
+
+    {
+      acc with
+      max_value;
+      min_value;
+      sum_value = List.fold_left ( +. ) acc.sum_value xs;
+      value_count = acc.value_count + List.length xs;
+      distribution;
+      rev_evolution;
+      ma;
+      next_in_idx = acc.next_in_idx + 1;
+      next_out_idx;
+    }
+
+  let finalise acc =
+    assert (acc.next_out_idx = acc.out_sample_count);
+    assert (acc.next_out_idx = List.length acc.rev_evolution);
+    assert (acc.next_in_idx = acc.in_period_count);
+    let f = match acc.scale with `Linear -> Fun.id | `Log -> Float.exp in
+    let distribution =
+      let open Bentov in
+      bins acc.distribution |> List.map (fun b -> (f b.center, b.count))
+    in
+    let evolution = List.rev_map f acc.rev_evolution in
+    {
+      max_value = acc.max_value;
+      min_value = acc.min_value;
+      mean = acc.sum_value /. float_of_int acc.value_count;
+      distribution;
+      evolution;
+    }
+end
+
+module Parallel_folders = struct
+  type ('row, 'acc, 'v) folder = {
+    acc : 'acc;
+    accumulate : 'acc -> 'row -> 'acc;
+    finalise : 'acc -> 'v;
+  }
+
+  let folder acc accumulate finalise = { acc; accumulate; finalise }
+
+  type ('res, 'row, 'v) folders =
+    | F0 : ('res, 'row, 'res) folders
+    | F1 :
+        ('row, 'acc, 'v) folder * ('res, 'row, 'rest) folders
+        -> ('res, 'row, 'v -> 'rest) folders
+
+  type ('res, 'row, 'f, 'rest) open_t =
+    ('res, 'row, 'rest) folders -> 'f * ('res, 'row, 'f) folders
+
+  let open_ : 'f -> ('res, 'row, 'f, 'f) open_t =
+   fun constructor folders -> (constructor, folders)
+
+  let app :
+      type res f v rest acc row.
+      (res, row, f, v -> rest) open_t ->
+      (row, acc, v) folder ->
+      (res, row, f, rest) open_t =
+   fun open_t folder folders -> open_t (F1 (folder, folders))
+
+  let ( |+ ) = app
+
+  type ('res, 'row) t = T : 'f * ('res, 'row, 'f) folders -> ('res, 'row) t
+
+  let seal : type res row f. (res, row, f, res) open_t -> (res, row) t =
+   fun open_t ->
+    let constructor, folders = open_t F0 in
+    T (constructor, folders)
+
+  let accumulate : type res row. (res, row) t -> row -> (res, row) t =
+   fun (T (constructor, folders)) row ->
+    let rec aux : type v. (res, row, v) folders -> (res, row, v) folders =
+      function
+      | F0 -> F0
+      | F1 (folder, t) as f -> (
+          let acc = folder.acc in
+          let acc' = folder.accumulate acc row in
+          let t' = aux t in
+          (* Avoid reallocating [F1] and [folder] when possible. *)
+          match (acc == acc', t == t') with
+          | true, true -> f
+          | true, false -> F1 (folder, t')
+          | false, (true | false) -> F1 ({ folder with acc = acc' }, t'))
+    in
+    let folders = aux folders in
+    T (constructor, folders)
+
+  let finalise : type res row. (res, row) t -> res =
+    let rec aux : type c. (res, row, c) folders -> c -> res = function
+      | F0 -> Fun.id
+      | F1 (f, fs) ->
+          fun constructor ->
+            let v = f.finalise f.acc in
+            let finalise_remaining = aux fs in
+            let constructor = constructor v in
+            finalise_remaining constructor
+    in
+    fun (T (constructor, folders)) -> aux folders constructor
+end

--- a/bench/trace_stat_summary_utils.mli
+++ b/bench/trace_stat_summary_utils.mli
@@ -1,0 +1,392 @@
+(** Utilities to summarise data.
+
+    This file is NOT meant to be used from Tezos, as opposed to some other
+    "trace_*" files. *)
+
+type histo = (float * int) list [@@deriving repr]
+type curve = float list [@@deriving repr]
+
+val snap_to_integer : significant_digits:int -> float -> float
+(** [snap_to_integer ~significant_digits v] is [Float.round v] if [v] is close
+    to [Float.round v], otherwise the result is [v]. [significant_digits]
+    defines how close things are.
+
+    Examples:
+
+    When [significant_digits] is [4] and [v] is [42.00001], [snap_to_integer v]
+    is [42.].
+
+    When [significant_digits] is [4] and [v] is [42.001], [snap_to_integer v] is
+    [v]. *)
+
+val create_pp_real :
+  ?significant_digits:int -> float list -> Format.formatter -> float -> unit
+(** [create_pp_real examples] is [pp_real], a float pretty-printer that adapts
+    to the [examples] shown to it.
+
+    It is highly recommended, but not mandatory, for all the numbers passed to
+    [pp_real] to be included in [examples].
+
+    When all the [examples] are integers, the display may be different. The
+    examples that aren't integer, but that are very close to be a integers are
+    counted as integers. [significant_digits] is used internally to snap the
+    examples to integers. *)
+
+val create_pp_seconds : float list -> Format.formatter -> float -> unit
+(** [create_pp_seconds examples] is [pp_seconds], a time span pretty-printer
+    that adapts to the [examples] shown to it.
+
+    It is highly recommended, but not mandatory, for all the numbers passed to
+    [pp_seconds] to be included [examples]. *)
+
+val pp_percent : Format.formatter -> float -> unit
+(** Pretty prints a percent in a way that always takes 4 chars.
+
+    Examples: [0.] is ["  0%"], [0.00001] is ["0.0%"], [0.003] is ["0.3%"],
+    [0.15] is [" 15%"], [9.0] is [900%], [700.] is [700x], [410_000.0] is
+    ["4e6x"] and [1e100] is ["++++"].
+
+    Negative inputs are undefined. *)
+
+(** Functional Exponential Moving Average (EMA). *)
+module Exponential_moving_average : sig
+  type t
+
+  val create : ?relevance_threshold:float -> float -> t
+  (** [create ?relevance_threshold m] is [ema], a functional exponential moving
+      average. [1. -. m] is the fraction of what's forgotten of the past during
+      each [update].
+
+      The value represented by [ema] can be retrieved using [peek_exn ema] or
+      [peek_or_nan ema].
+
+      When [m = 0.], all the past is forgotten on each update and each forget.
+      [peek_exn ema] is either the latest sample fed to an update function or
+      [nan].
+
+      When [m] approaches [1.], [peek_exn ema] tends to be the mean of all the
+      samples seen in the past.
+
+      See
+      https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
+
+      {3 Relevance}
+
+      The value represented by [ema] is built from the {e history} of samples
+      shown through [update(_batch)]. When that history is empty, the value
+      can't be calculated, and when the history is too small, or too distant
+      because of calls to [forget(_batch)], the represented value is very noisy.
+
+      [relevance_threshold] is a threshold on [ema]'s inner [void_fraction],
+      below which the represented value should be considered relevant, i.e.
+      [peek_or_nan ema] is not NaN.
+
+      Before any call to [update(_batch)], the represented value is always
+      irrelevant.
+
+      After a sufficient number of updates (e.g. 1 update in general), the
+      represented value gets relevant.
+
+      After a sufficient number of forgets, the represented value gets
+      irrelevant again.
+
+      A good value for [relevance_threshold] is between [momentum] and [1.], so
+      that right after a call to [update], the value is always relevant.
+
+      {3 Commutativity}
+
+      Adding together two curves independently built with an EMA, is equivalent
+      to adding the samples beforehand, and using a single EMA.
+
+      In a more more formal way:
+
+      Let [a], [b] be vectors of real values of similar length.
+
+      Let [ema(x)] be the [Exponential_moving_average.map momentum] function
+      ([float list -> float list]);
+
+      Let [*], [+] and [/] be the element-wise vector multiplication, addition
+      and division.
+
+      Then [ema(a + b)] is [ema(a) + ema(b)].
+
+      The same is not true for multiplication and division, [ema(a * b)] is not
+      [ema(a) * ema(b)], but [exp(ema(log(a * b)))] is
+      [exp(ema(log(a))) * exp(ema(log(b)))] when all values in [a] and [b] are
+      strictly greater than 0. *)
+
+  val from_half_life : ?relevance_threshold:float -> float -> t
+  (** [from_half_life hl] is [ema], a functional exponential moving average.
+      After [hl] calls to [update], half of the past is forgotten. *)
+
+  val from_half_life_ratio : ?relevance_threshold:float -> float -> float -> t
+  (** [from_half_life_ratio hl_ratio step_count] is [ema], a functional
+      exponential moving average. After [hl_ratio * step_count] calls to
+      [update], half of the past is forgotten. *)
+
+  val map : ?relevance_threshold:float -> float -> float list -> float list
+  (** [map momentum vec0] is [vec1], a list of float with the same length as
+      [vec0], where the values have been locally averaged.
+
+      The first element of [vec1] is also the first element of [vec0]. *)
+
+  val update : t -> float -> t
+  (** Feed a new sample to the EMA. If the sample is not finite (i.e., NaN or
+      infinite), the represented won't be either. *)
+
+  val update_batch : t -> float -> float -> t
+  (** [update_batch ema p s] is equivalent to calling [update] [s] times. Modulo
+      floating point errors. *)
+
+  val forget : t -> t
+  (** [forget ema] forgets some of the past without the need for samples. The
+      represented value doesn't change. *)
+
+  val forget_batch : t -> float -> t
+  (** [forget_batch ema s] is equivalent to calling [forget] [s] times. Modulo
+      floating point errors.*)
+
+  val is_relevant : t -> bool
+  (** Indicates whether or not [peek_exn] can be called without raising an
+      exception. *)
+
+  val peek_exn : t -> float
+  (** Read the EMA value. *)
+
+  val peek_or_nan : t -> float
+  (** Read the EMA value. *)
+
+  val momentum : t -> float
+  val hidden_state : t -> float
+  val void_fraction : t -> float
+end
+
+(** This [Resample] module offers 3 ways to resample a 1d vector:
+
+    - At the lowest level, using [should_sample].
+    - Using [create_acc] / [accumulate] / [finalise].
+    - At the highest level, using [resample_vector].
+
+    Both downsampling and upsampling are possible:
+
+    {v
+    > upsampling
+    vec0: |       |       |        |  (len0:4)
+    vec1: |    |    |    |    |    |  (len1:6)
+    > identity
+    vec0: |       |       |        |  (len0:4)
+    vec1: |       |       |        |  (len1:4)
+    > downsampling
+    vec0: |    |    |    |    |    |  (len0:6)
+    vec1: |       |       |        |  (len1:4)
+    v}
+
+    The first and last point of the input and output sequences are always equal. *)
+module Resample : sig
+  val should_sample :
+    i0:int ->
+    len0:int ->
+    i1:int ->
+    len1:int ->
+    [ `After | `Before | `Inside of float | `Out_of_bounds ]
+  (** When resampling a 1d vector from [len0] to [len1], this function locates a
+      destination point with index [i1] relative to the range [i0 - 1] excluded
+      and [i0] included.
+
+      When both [i0] and [i1] equal [0], the result is [`Inside 1.].
+
+      [len0] and [len1] should be greater or equal to 2. *)
+
+  type acc
+
+  val create_acc :
+    [ `Interpolate | `Next_neighbor ] ->
+    len0:int ->
+    len1:int ->
+    v00:float ->
+    acc
+  (** Creates a resampling accumulator.
+
+      Requires the first point of vec0. *)
+
+  val accumulate : acc -> float -> acc
+  val finalise : acc -> curve
+
+  val resample_vector :
+    [< `Interpolate | `Next_neighbor ] -> curve -> int -> curve
+  (** [resample_vector mode vec0 len1] is [vec1], a curve of length [len1],
+      created by resampling [vec0].
+
+      It internally relies on the [should_sample] function. *)
+end
+
+(** Functional summary for a variable that has zero or more occurences per
+    period. [accumulate] is expected to be called [in_period_count] times before
+    [finalise] is.
+
+    {3 Stats Gathered}
+
+    - Global max, argmax, min, argmin and mean of the variable.
+    - Global histogram made of [distribution_bin_count] bins. Option:
+      [distribution_scale] to control the spreading scale of the bins, either on
+      a linear or a log scale. Computed using Bentov.
+    - A curve made of [out_sample_count] points. Options: [evolution_smoothing]
+      to control the smoothing, either using EMA, or no smoothing at all.
+
+    {3 Histograms}
+
+    The histograms are all computed using https://github.com/barko/bentov.
+
+    [Bentov] computes dynamic histograms without the need for a priori
+    informations on the distributions, while maintaining a constant memory space
+    and a marginal CPU footprint.
+
+    The implementation of that library is pretty straightforward, but not
+    perfect; the CPU footprint doesn't scale well with the number of bins.
+
+    The computed histograms depend on the order of the operations, some marginal
+    unsabilities are to be expected.
+
+    [Bentov] is good at spreading the bins on the input space. Since some
+    histograms will be shown on a log plot, the log10 of those values is passed
+    to [Bentov] instead, but the json will store real seconds.
+
+    {3 Log Scale}
+
+    When a variable has to be displayed on a log scale, the [scale] option can
+    be set to [`Log] in order for some adjustments to be made.
+
+    In the histogram, the bins have to spread on a log scale.
+
+    When smoothing the evolution, the EMA decay has to be calculated on a log
+    scale.
+
+    Gotcha: All the input samples should be strictly greater than 0, so that
+    they don't fail their conversion to log.
+
+    {3 Periods are Decoupled from Samples}
+
+    When a [Variable_summary] ([vs]) is created, the number of periods has to be
+    declared right away through the [in_period_count] parameter, but [vs] is
+    very flexible when it comes to the number of samples shown to it on each
+    period.
+
+    The simplest use case of [vs] is when there is exactly one sample for each
+    period. In that case, [accumulate acc samples] is called using a list of
+    length 1. For example: when a period corresponds to a cycle of an algorithm,
+    and the variable is a timestamp.
+
+    The more advanced use case of [vs] is when there are a varying number a
+    samples for each period. For example: when a period corresponds to a cycle
+    of an algorithm, and the variable is the time taken by a buffer flush that
+    may happen 0, 1 or more times per cycle.
+
+    In that later case, the [evolution] curve may contain NaNs before and after
+    sample points.
+
+    {3 Possible Future Evolutions}
+
+    - A period-wise histogram, similar to Grafana's heatmaps: "A heatmap is like
+      a histogram, but over time where each time slice represents its own
+      histogram.".
+
+    - Variance evolution. Either without smoothing or using exponential moving
+      variance (see wikipedia).
+
+    - Global variance.
+
+    - Quantile evolution. *)
+module Variable_summary : sig
+  type t = {
+    max_value : float * int;
+    min_value : float * int;
+    mean : float;
+    distribution : histo;
+    evolution : curve;
+  }
+  [@@deriving repr]
+
+  type acc
+
+  val create_acc :
+    evolution_smoothing:[ `Ema of float * float | `None ] ->
+    evolution_resampling_mode:[ `Interpolate | `Next_neighbor | `Prev_neighbor ] ->
+    distribution_bin_count:int ->
+    scale:[ `Linear | `Log ] ->
+    in_period_count:int ->
+    out_sample_count:int ->
+    acc
+
+  val accumulate : acc -> float list -> acc
+  val finalise : acc -> t
+end
+
+(** See [Trace_stat_summary] for an explanation and an example.
+
+    Heavily inspired by the "repr" library.
+
+    Type parameters:
+
+    - ['res] is the output of [finalise].
+    - ['f] is the full contructor that creates a ['res].
+    - ['v] is the output of [folder.finalise], one parameter of ['f].
+    - ['rest] is ['f] or ['res] or somewhere in between.
+    - ['acc] is the accumulator of one folder.
+    - ['row] is what needs to be fed to all [folder.accumulate].
+
+    Typical use case:
+
+    {[
+      let pf =
+        open_ (fun res_a res_b -> my_constructor res_a res_b)
+        |+ folder my_acc_a my_accumulate_a my_finalise_a
+        |+ folder my_acc_b my_accumulate_b my_finalise_b
+        |> seal
+      in
+      let res = my_row_sequence |> Seq.fold_left accumulate pf |> finalise in
+    ]} *)
+module Parallel_folders : sig
+  (** Section 1/3 - Individual folders *)
+
+  type ('row, 'acc, 'v) folder
+
+  val folder :
+    'acc -> ('acc -> 'row -> 'acc) -> ('acc -> 'v) -> ('row, 'acc, 'v) folder
+  (** Create one folder to be passed to an open parallel folder using [|+]. *)
+
+  (** Section 2/3 - Open parallel folder *)
+
+  type ('res, 'row, 'v) folders
+  type ('res, 'row, 'f, 'rest) open_t
+
+  val open_ : 'f -> ('res, 'row, 'f, 'f) open_t
+  (** Start building a parallel folder. *)
+
+  val app :
+    ('res, 'row, 'f, 'v -> 'rest) open_t ->
+    ('row, 'acc, 'v) folder ->
+    ('res, 'row, 'f, 'rest) open_t
+  (** Add a folder to an open parallel folder. *)
+
+  val ( |+ ) :
+    ('res, 'row, 'f, 'v -> 'rest) open_t ->
+    ('row, 'acc, 'v) folder ->
+    ('res, 'row, 'f, 'rest) open_t
+  (** Alias for [app]. *)
+
+  (** Section 3/3 - Closed parallel folder *)
+
+  type ('res, 'row) t
+
+  val seal : ('res, 'row, 'f, 'res) open_t -> ('res, 'row) t
+  (** Stop building a parallel folder.
+
+      Gotcha: It may seal a partially applied [f]. *)
+
+  val accumulate : ('res, 'row) t -> 'row -> ('res, 'row) t
+  (** Forward a row to all registered functional folders. *)
+
+  val finalise : ('res, 'row) t -> 'res
+  (** Finalise all folders and pass their result to the user-defined function
+      provided to [open_]. *)
+end

--- a/bench/trace_stats.ml
+++ b/bench/trace_stats.ml
@@ -1,0 +1,185 @@
+(*
+ * Copyright (c) 2018-2021 Tarides <contact@tarides.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** [trace_stats.exe].
+
+    This file is NOT meant to be used from Tezos, as opposed to some other
+    "trace_*" files. *)
+
+open Irmin_traces
+module Def = Trace_definitions.Stat_trace
+module Summary = Trace_stat_summary
+
+let is_trace_magic s = Trace_common.Magic.to_string Def.magic = s
+
+let summarise path =
+  Summary.(summarise path |> Fmt.pr "%a\n" (Irmin.Type.pp_json t))
+
+let class_of_path p =
+  let chan = open_in_bin p in
+  if in_channel_length chan < 8 then
+    Fmt.invalid_arg "File \"%s\" should be a stat trace or a json." p;
+  let magic = really_input_string chan 8 in
+  close_in chan;
+  if is_trace_magic magic then
+    let block_count =
+      Def.open_reader p
+      |> snd
+      |> Seq.fold_left
+           (fun count op -> match op with `Commit _ -> count + 1 | _ -> count)
+           0
+    in
+    `Trace block_count
+  else
+    let chan = open_in_bin p in
+    let raw = really_input_string chan (in_channel_length chan) in
+    close_in chan;
+    match Irmin.Type.of_json_string Summary.t raw with
+    | Error (`Msg msg) ->
+        Fmt.invalid_arg
+          "File \"%s\" should be a stat trace or a json.\nError: %s" p msg
+    | Ok s -> `Summary s
+
+let pp name_per_path paths cols_opt =
+  let class_per_path = List.map class_of_path paths in
+  let block_count =
+    (* When pretty printing, all the summaries will have to have the same number of
+       blocks, i.e. the smallest of all inputs. *)
+    let trace_lengths =
+      List.filter_map
+        (function `Trace v -> Some v | `Summary _ -> None)
+        class_per_path
+    in
+    let summary_lengths =
+      List.filter_map
+        (function `Trace _ -> None | `Summary s -> Some s.Summary.block_count)
+        class_per_path
+    in
+    let s = List.length summary_lengths > 0 in
+    let t = List.length trace_lengths > 0 in
+    let min_trace_length = List.fold_left min max_int trace_lengths in
+    let min_summary_length = List.fold_left min max_int summary_lengths in
+    let max_summary_length = List.fold_left max 0 summary_lengths in
+    if s && min_summary_length <> max_summary_length then
+      invalid_arg
+        "Can't pretty print 2 summaries with a different number of blocks.";
+    if s && t && min_summary_length > min_trace_length then
+      invalid_arg
+        "Can't pretty print a trace alongside a summary that has a higher \
+         block count.";
+    min min_trace_length min_summary_length
+  in
+  let summaries =
+    List.map2
+      (fun path -> function
+        | `Summary s -> s
+        | `Trace _ -> Summary.summarise ~block_count path)
+      paths class_per_path
+  in
+  let col_count =
+    match cols_opt with
+    | Some v -> v
+    | None -> if List.length summaries > 1 then 4 else 5
+  in
+  Fmt.pr "%a\n" (Trace_stat_summary_pp.pp col_count) (name_per_path, summaries)
+
+let pp paths named_paths cols_opt =
+  let name_per_path, paths =
+    List.mapi (fun i v -> (string_of_int i, v)) paths @ named_paths
+    |> List.split
+  in
+  if List.length paths = 0 then
+    invalid_arg "trace_stats.exe pp: At least one path should be provided";
+  pp name_per_path paths cols_opt
+
+open Cmdliner
+
+let term_summarise =
+  let stat_trace_file =
+    let doc = Arg.info ~docv:"PATH" ~doc:"A stat trace file" [] in
+    Arg.(required @@ pos 0 (some string) None doc)
+  in
+  Term.(const summarise $ stat_trace_file)
+
+let term_pp =
+  let arg_indexed_files =
+    let open Arg in
+    let a = pos_all non_dir_file [] (info [] ~docv:"FILE") in
+    value a
+  in
+  let arg_named_files =
+    let open Arg in
+    let a =
+      opt_all (pair string non_dir_file) []
+        (info [ "f"; "named-file" ]
+           ~doc:
+             "A comma-separated pair of short name / path to trace or summary. \
+              The short name is used to tag the rows inside the pretty printed \
+              table.")
+    in
+    value a
+  in
+  let arg_columns =
+    let open Arg in
+    let doc =
+      Arg.info ~doc:"Number of sample columns to show." [ "c"; "columns" ]
+    in
+    let a = opt (some int) None doc in
+    value a
+  in
+  Term.(const pp $ arg_indexed_files $ arg_named_files $ arg_columns)
+
+let () =
+  let man = [] in
+  let i =
+    Term.info ~man ~doc:"Processing of stat traces and stat trace summaries."
+      "trace_stats"
+  in
+
+  let man =
+    [
+      `P "From stat trace (repr) to summary (json).";
+      `S "EXAMPLE";
+      `P "trace_stats.exe summarise run0.repr > run0.json";
+    ]
+  in
+  let j = Term.info ~man ~doc:"Stat Trace to Summary" "summarise" in
+
+  let man =
+    [
+      `P
+        "Accepts both stat traces (repr) and summaries (json). The file type \
+         is automatically infered.";
+      `P
+        "When a single file is provided, a subset of the summary of that file \
+         is computed and shown.";
+      `P
+        "When multiple files are provided, a subset of the summary of each \
+         file is computed and shown in a way that makes comparisons between \
+         files easy.";
+      `S "EXAMPLES";
+      `P "trace_stats.exe pp run0.json";
+      `Noblank;
+      `P "trace_stats.exe pp run1.repr";
+      `Noblank;
+      `P "trace_stats.exe pp run0.json run1.repr run3.json";
+      `Noblank;
+      `P "trace_stats.exe pp -f r0,run0.json -f r1,run1.repr";
+    ]
+  in
+  let k = Term.info ~man ~doc:"Comparative Pretty Printing" "pp" in
+  Term.exit
+  @@ Term.eval_choice (term_summarise, i) [ (term_summarise, j); (term_pp, k) ]

--- a/bin/client/client.ml
+++ b/bin/client/client.ml
@@ -84,7 +84,7 @@ let set client key author message contents =
         Irmin.Type.of_string Client.Contents.t contents
         |> Error.unwrap "contents"
       in
-      let info = Irmin_unix.info ~author "%s" message in
+      let info = Client.Info.v ~author "%s" message in
       let+ () =
         Client.Store.set client key ~info contents >|= Error.unwrap "set"
       in
@@ -94,7 +94,7 @@ let remove client key author message =
   run (fun () ->
       client >>= fun (S ((module Client), client)) ->
       let key = Irmin.Type.of_string Client.Key.t key |> Error.unwrap "key" in
-      let info = Irmin_unix.info ~author "%s" message in
+      let info = Client.Info.v ~author "%s" message in
       let+ () =
         Client.Store.remove client key ~info >|= Error.unwrap "remove"
       in

--- a/bin/client/dashboard.ml
+++ b/bin/client/dashboard.ml
@@ -53,13 +53,13 @@ let commit_diff (type a) (module Client : Irmin_client.S with type commit = a) x
     =
   let pr t a =
     let info = Client.Commit.info a in
-    let date = Irmin.Info.date info in
+    let date = Client.Info.date info in
     let localtime = Unix.localtime (Int64.to_float date) in
     W.printf "%s (%04d-%02d-%02d %02d:%02d:%02d)\ncommit: %s\ninfo: %s\n" t
       (localtime.tm_year + 1900) (localtime.tm_mon + 1) localtime.tm_mday
       localtime.tm_hour localtime.tm_min localtime.tm_sec
       (Irmin.Type.to_string Client.Hash.t (Client.Commit.hash a))
-      (Irmin.Type.to_string Irmin.Info.t info)
+      (Irmin.Type.to_string Client.Info.t info)
   in
   match x with
   | `Added a -> pr "Added" a

--- a/bin/client/dashboard.ml
+++ b/bin/client/dashboard.ml
@@ -7,46 +7,91 @@ module Ui = Nottui.Ui
 
 let handle_keyboard = function `Escape, _ -> exit 0 | _, _ -> `Unhandled
 
+let bold = Notty.A.(st bold)
+
+let magenta = Notty.A.(fg magenta)
+
+module Widget = struct
+  type 'a t = { value : 'a Lwd.var; show : 'a -> Ui.t }
+
+  let v show value =
+    let value = Lwd.var value in
+    { show; value }
+
+  let show_title title fmt x = (W.printf ~attr:bold "%s: " title, W.printf fmt x)
+
+  let display title fmt value =
+    let show x =
+      let title, value = show_title title fmt x in
+      Ui.hcat [ title; value ]
+    in
+    v show value
+
+  let get_value widget = Lwd.get widget.value
+
+  let set_value widget x = Lwd.set widget.value x
+
+  let show { show; value } =
+    let open Lwd_infix in
+    let$ x = Lwd.get value in
+    show x
+end
+
+let uptime = Widget.display "Uptime" "%.0fs" 0.0
+
+let pack =
+  Widget.v
+    (fun (adds, finds, cache_misses) ->
+      Ui.vcat
+        [
+          W.printf ~attr:Notty.A.(st bold) "Pack:";
+          W.printf "Adds: %d" adds;
+          W.printf "Finds: %d" finds;
+          W.printf "Cache misses: %d" cache_misses;
+        ])
+    (0, 0, 0)
+
+let last_update (type a) (module Client : Irmin_client.S with type commit = a) =
+  Widget.v
+    (fun last_update ->
+      let last_update =
+        match last_update with
+        | Some last_update ->
+            Irmin.Type.to_json_string ~minify:false
+              (Irmin.Diff.t Client.Commit.t)
+              last_update
+        | None -> "n/a"
+      in
+      let title, value = Widget.show_title "Last update" "%s" last_update in
+      Ui.hcat [ title; value ])
+    None
+
 let main client freq =
   client >>= fun (S ((module Client), client)) ->
-  let uptime = Lwd.var 0.0 in
-  let adds = Lwd.var 0 in
-  let finds = Lwd.var 0 in
-  let cache_misses = Lwd.var 0 in
-  let last_update = Lwd.var None in
+  let last_update = last_update (module Client) in
   let ui =
     let open Lwd_infix in
-    let$* uptime = Lwd.get uptime in
-    let$* adds = Lwd.get adds in
-    let$* last_update = Lwd.get last_update in
-    let$* cache_misses = Lwd.get cache_misses in
-    let$ finds = Lwd.get finds in
-    let last_update =
-      match last_update with
-      | Some last_update ->
-          Irmin.Type.to_json_string ~minify:false
-            (Irmin.Diff.t Client.Commit.t)
-            last_update
-      | None -> "n/a"
-    in
+    let$* uptime = Widget.show uptime in
+    let$* pack = Widget.show pack in
+    let$ last_update = Widget.show last_update in
     Ui.keyboard_area handle_keyboard
       (Ui.vcat
          [
-           W.printf "Connected to: %s" (Client.uri client |> Uri.to_string);
-           W.printf "uptime: %.0fs" uptime;
-           W.printf "adds: %d" adds;
-           W.printf "finds: %d" finds;
-           W.printf "cache_misses: %d" cache_misses;
-           W.printf "last update: %s" last_update;
+           W.printf ~attr:magenta "Connected to: %s"
+             (Client.uri client |> Uri.to_string);
+           Ui.space 0 1;
+           uptime;
+           Ui.space 0 1;
+           pack;
+           Ui.space 0 1;
+           last_update;
          ])
   in
   let rec tick client () =
     Lwt.async (fun () ->
         let* stats = Client.stats client >|= Error.unwrap "stats" in
-        Lwd.set uptime stats.uptime;
-        Lwd.set adds stats.adds;
-        Lwd.set finds stats.finds;
-        Lwd.set cache_misses stats.cache_misses;
+        Widget.set_value uptime stats.uptime;
+        Widget.set_value pack (stats.adds, stats.finds, stats.cache_misses);
         let+ () = Lwt_unix.sleep freq in
         tick client ())
   in
@@ -54,7 +99,7 @@ let main client freq =
   let watch client () =
     Lwt.async (fun () ->
         let f x =
-          Lwd.set last_update (Some x);
+          Widget.set_value last_update (Some x);
           Lwt.return_ok `Continue
         in
         Client.Store.watch f client >|= Error.unwrap "watch")

--- a/bin/server/server.ml
+++ b/bin/server/server.ml
@@ -2,16 +2,30 @@ open Lwt.Syntax
 open Irmin_server_types
 
 let main ~root ~uri ~tls ~store ~contents ~hash =
+  let config =
+    match root with
+    | Some root -> Irmin_pack.config root
+    | None -> Irmin_mem.config ()
+  in
+  let config =
+    match uri with Some uri -> Irmin_http.config ~config uri | None -> config
+  in
   let store, config =
-    Irmin_unix.Resolver.load_config ~store ~hash ~contents ()
+    Irmin_unix.Resolver.load_config ~default:config ~store ~hash ~contents ()
   in
   let (module Store : Irmin.S), _ = Irmin_unix.Resolver.Store.destruct store in
   let module Server = Irmin_server.Make (Store) in
   let tls_config =
     match tls with Some (c, k) -> Some (`Cert_file c, `Key_file k) | _ -> None
   in
+  let uri =
+    Irmin.Private.Conf.(get config Irmin_http.uri)
+    |> Option.value ~default:Cli.default_uri
+  in
   let* server = Server.v ?tls_config ~uri config in
-  Logs.app (fun l -> l "Listening on %s, store: %s" uri root);
+  let root = Irmin.Private.Conf.(get config root) in
+  let root = match root with Some root -> root | None -> "<memory>" in
+  Logs.app (fun l -> l "Listening on %a, store: %s" Uri.pp_hum uri root);
   Server.serve server
 
 let main root uri tls (store, hash, contents) () =
@@ -21,7 +35,7 @@ open Cmdliner
 
 let root =
   let doc = Arg.info ~doc:"Irmin store path" [ "r"; "root" ] in
-  Arg.(value @@ opt string "/tmp/irmin-server" doc)
+  Arg.(value @@ opt (some string) None doc)
 
 let tls =
   let doc = Arg.info ~docv:"CERT_FILE,KEY_FILE" ~doc:"TLS config" [ "tls" ] in

--- a/irmin-server-bench.opam
+++ b/irmin-server-bench.opam
@@ -17,6 +17,8 @@ depends: [
   "ppx_deriving_yojson"
   "bentov"
   "benchmark"
+  "mtime"
+  "printbox"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/irmin-server-types.opam
+++ b/irmin-server-types.opam
@@ -31,43 +31,43 @@ dev-repo: "git+ssh://github.com/zshipko/irmin-server"
 pin-depends: [
   [
     "ppx_irmin.dev"
-    "git+https://github.com/mirage/irmin#2f58b86b3997dc7c8e1a0847ed5b42ea7201178f"
+    "git+https://github.com/mirage/irmin#b86b3da7869ecc48e9b964f9ba8cfc88b656bdb5"
   ]
   [
     "irmin.dev"
-    "git+https://github.com/mirage/irmin#2f58b86b3997dc7c8e1a0847ed5b42ea7201178f"
+    "git+https://github.com/mirage/irmin#b86b3da7869ecc48e9b964f9ba8cfc88b656bdb5"
   ]
   [
     "irmin-git.dev"
-    "git+https://github.com/mirage/irmin#2f58b86b3997dc7c8e1a0847ed5b42ea7201178f"
+    "git+https://github.com/mirage/irmin#b86b3da7869ecc48e9b964f9ba8cfc88b656bdb5"
   ]
   [
     "irmin-fs.dev"
-    "git+https://github.com/mirage/irmin#2f58b86b3997dc7c8e1a0847ed5b42ea7201178f"
+    "git+https://github.com/mirage/irmin#b86b3da7869ecc48e9b964f9ba8cfc88b656bdb5"
   ]
   [
     "irmin-graphql.dev"
-    "git+https://github.com/mirage/irmin#2f58b86b3997dc7c8e1a0847ed5b42ea7201178f"
+    "git+https://github.com/mirage/irmin#b86b3da7869ecc48e9b964f9ba8cfc88b656bdb5"
   ]
   [
     "irmin-http.dev"
-    "git+https://github.com/mirage/irmin#2f58b86b3997dc7c8e1a0847ed5b42ea7201178f"
+    "git+https://github.com/mirage/irmin#b86b3da7869ecc48e9b964f9ba8cfc88b656bdb5"
   ]
   [
     "irmin-layers.dev"
-    "git+https://github.com/mirage/irmin#2f58b86b3997dc7c8e1a0847ed5b42ea7201178f"
+    "git+https://github.com/mirage/irmin#b86b3da7869ecc48e9b964f9ba8cfc88b656bdb5"
   ]
   [
     "irmin-pack.dev"
-    "git+https://github.com/mirage/irmin#2f58b86b3997dc7c8e1a0847ed5b42ea7201178f"
+    "git+https://github.com/mirage/irmin#b86b3da7869ecc48e9b964f9ba8cfc88b656bdb5"
   ]
   [
     "irmin-unix.dev"
-    "git+https://github.com/mirage/irmin#2f58b86b3997dc7c8e1a0847ed5b42ea7201178f"
+    "git+https://github.com/zshipko/irmin#49eaa7140f04fe73cff52cf8986e0af7fd5a584"
   ]
   [
     "irmin-test.dev"
-    "git+https://github.com/mirage/irmin#2f58b86b3997dc7c8e1a0847ed5b42ea7201178f"
+    "git+https://github.com/mirage/irmin#b86b3da7869ecc48e9b964f9ba8cfc88b656bdb5"
   ]
   [
     "index.dev"

--- a/irmin-server-types.opam
+++ b/irmin-server-types.opam
@@ -63,7 +63,7 @@ pin-depends: [
   ]
   [
     "irmin-unix.dev"
-    "git+https://github.com/zshipko/irmin#49eaa7140f04fe73cff52cf8986e0af7fd5a584"
+    "git+https://github.com/zshipko/irmin#066929faa7b795064128870e02ed9445cbeaefe4"
   ]
   [
     "irmin-test.dev"

--- a/src/irmin-client/client.ml
+++ b/src/irmin-client/client.ml
@@ -10,6 +10,12 @@ module Make (C : Command.S) = struct
   module Key = Store.Key
   module Metadata = Store.Metadata
 
+  module Info = struct
+    include Irmin_unix.Info (Store.Info)
+
+    let init = Store.Info.v
+  end
+
   module Private = struct
     module Store = C.Store
     module Tree = C.Tree

--- a/src/irmin-client/client.ml
+++ b/src/irmin-client/client.ml
@@ -58,7 +58,6 @@ module Make (C : Command.S) = struct
   type tree = t * Private.Tree.t * batch
 
   let conf ?(batch_size = 32) ?(tls = false) ~uri () =
-    let uri = Uri.of_string uri in
     let scheme = Uri.scheme uri |> Option.value ~default:"tcp" in
     let addr = Uri.host_with_default ~default:"127.0.0.1" uri in
     let client =

--- a/src/irmin-client/client.ml
+++ b/src/irmin-client/client.ml
@@ -440,7 +440,7 @@ module Make (C : Command.S) = struct
           match res with
           | Ok x ->
               let x = Private.Tree.Local.of_concrete x in
-              Ok x
+              Ok (x : Private.Store.tree)
           | Error e -> Error e)
 
     let of_local t x =

--- a/src/irmin-client/client_intf.ml
+++ b/src/irmin-client/client_intf.ml
@@ -27,6 +27,14 @@ module type S = sig
 
   val slice_t : slice Irmin.Type.t
 
+  module Info : sig
+    include Irmin.Info.S
+
+    val init : ?author:string -> ?message:string -> int64 -> t
+
+    val v : ?author:string -> ('b, Format.formatter, unit, f) format4 -> 'b
+  end
+
   module Key : Irmin.Path.S with type t = key and type step = step
 
   module Hash : Irmin.Hash.S with type t = hash
@@ -77,11 +85,7 @@ module type S = sig
 
   module Commit : sig
     val v :
-      t ->
-      info:Irmin.Info.f ->
-      parents:hash list ->
-      tree ->
-      commit Error.result Lwt.t
+      t -> info:Info.f -> parents:hash list -> tree -> commit Error.result Lwt.t
     (** Create a new commit
         NOTE: this will invalidate all intermediate trees *)
 
@@ -93,7 +97,7 @@ module type S = sig
     val parents : commit -> hash list
     (** The commit parents. *)
 
-    val info : commit -> Irmin.Info.t
+    val info : commit -> Info.t
     (** The commit info. *)
 
     val t : commit Irmin.Type.t
@@ -222,31 +226,30 @@ module type S = sig
     val find_tree : t -> key -> Tree.t option Error.result Lwt.t
     (** Find the tree associated with a key, if it exists *)
 
-    val set :
-      t -> info:Irmin.Info.f -> key -> contents -> unit Error.result Lwt.t
+    val set : t -> info:Info.f -> key -> contents -> unit Error.result Lwt.t
     (** Associate a new value with the given key *)
 
     val test_and_set :
       t ->
-      info:Irmin.Info.f ->
+      info:Info.f ->
       key ->
       test:contents option ->
       set:contents option ->
       unit Error.result Lwt.t
     (** Set a value only if the [test] parameter matches the existing value *)
 
-    val remove : t -> info:Irmin.Info.f -> key -> unit Error.result Lwt.t
+    val remove : t -> info:Info.f -> key -> unit Error.result Lwt.t
     (** Remove a value from the store *)
 
     val set_tree :
-      t -> info:Irmin.Info.f -> key -> Tree.t -> Tree.t Error.result Lwt.t
+      t -> info:Info.f -> key -> Tree.t -> Tree.t Error.result Lwt.t
     (** Set a tree at the given key
         NOTE: the tree parameter will not be valid after this call, the
         returned tree should be used instead *)
 
     val test_and_set_tree :
       t ->
-      info:Irmin.Info.f ->
+      info:Info.f ->
       key ->
       test:Tree.t option ->
       set:Tree.t option ->
@@ -261,10 +264,9 @@ module type S = sig
     val mem_tree : t -> key -> bool Error.result Lwt.t
     (** Check if the given key has an associated tree *)
 
-    val merge : t -> info:Irmin.Info.f -> branch -> unit Error.result Lwt.t
+    val merge : t -> info:Info.f -> branch -> unit Error.result Lwt.t
 
-    val merge_commit :
-      t -> info:Irmin.Info.f -> Commit.t -> unit Error.result Lwt.t
+    val merge_commit : t -> info:Info.f -> Commit.t -> unit Error.result Lwt.t
 
     val last_modified : t -> key -> Commit.t list Error.result Lwt.t
 

--- a/src/irmin-client/client_intf.ml
+++ b/src/irmin-client/client_intf.ml
@@ -57,7 +57,7 @@ module type S = sig
       | `Tree of Private.Tree.t ])
     list
 
-  val connect : ?batch_size:int -> ?tls:bool -> uri:string -> unit -> t Lwt.t
+  val connect : ?batch_size:int -> ?tls:bool -> uri:Uri.t -> unit -> t Lwt.t
   (** Connect to the server specified by [uri] *)
 
   val uri : t -> Uri.t

--- a/src/irmin-client/client_intf.ml
+++ b/src/irmin-client/client_intf.ml
@@ -52,11 +52,7 @@ module type S = sig
          and type slice = slice
          and type metadata = metadata
 
-    module Tree :
-      Tree.S
-        with type Private.Store.hash = hash
-         and type Private.Store.contents = contents
-         and type Private.Store.branch = branch
+    module Tree : Tree.S with module Private.Store = Store
   end
 
   type batch =
@@ -202,12 +198,12 @@ module type S = sig
 
     val merge : old:tree -> tree -> tree -> tree Error.result Lwt.t
 
-    module Local :
-      Tree.LOCAL
-        with type key = key
-         and type contents = contents
-         and type hash = hash
-         and type step = Key.step
+    module Local = Private.Tree.Local
+    (*with type key = key
+      and type contents = contents
+      and type hash = hash
+      and type step = Key.step
+      and type t = Private.Store.tree*)
 
     val to_local : tree -> Local.t Error.result Lwt.t
     (** Exchange [tree], which may be a hash or ID, for a tree
@@ -289,4 +285,7 @@ module type Client = sig
        and type commit = C.Commit.t
        and type step = C.Store.step
        and type metadata = C.Store.metadata
+       and type slice = C.Store.slice
+       and module Private.Store = C.Store
+       and type Private.Store.tree = C.Store.tree
 end

--- a/src/irmin-client/irmin_client_intf.ml
+++ b/src/irmin-client/irmin_client_intf.ml
@@ -14,4 +14,7 @@ module type Irmin_client = sig
        and type key = Store.key
        and type step = Store.step
        and type metadata = Store.metadata
+       and type slice = Store.slice
+       and module Private.Store = Store
+       and type Private.Store.tree = Store.tree
 end

--- a/src/irmin-server-types/cli.ml
+++ b/src/irmin-server-types/cli.ml
@@ -6,30 +6,17 @@ let uri : string Cmdliner.Term.t =
   in
   Arg.(value & opt string "tcp://127.0.0.1:8888" & doc)
 
-let log_level =
-  let level =
-    let parse str =
-      match Logs.level_of_string str with
-      | Ok x -> `Ok x
-      | Error (`Msg s) -> `Error s
-    in
-    let print ppf path =
-      Format.pp_print_string ppf (Logs.level_to_string path)
-    in
-    (parse, print)
-  in
-  let doc =
-    Arg.info ~docv:"LEVEL" ~doc:"Log level (app, info, error, debug)"
-      [ "log-level" ]
-  in
-  Arg.(required & opt level (Some Logs.App) & doc)
-
 let contents = Irmin_unix.Resolver.Contents.term
 
 let hash = Irmin_unix.Resolver.Hash.term
 
-let default_hash = (module Irmin.Hash.BLAKE2B : Irmin.Hash.S)
+let store = Irmin_unix.Resolver.Store.term
 
-let store = Irmin_unix.Resolver.store
+let setup_log style_renderer level =
+  Fmt_tty.setup_std_outputs ?style_renderer ();
+  Logs.set_level level;
+  Logs.set_reporter (Logs_fmt.reporter ());
+  ()
 
-let default_contents = "string"
+let setup_log =
+  Term.(const setup_log $ Fmt_cli.style_renderer () $ Logs_cli.level ())

--- a/src/irmin-server-types/cli.ml
+++ b/src/irmin-server-types/cli.ml
@@ -10,7 +10,9 @@ let contents = Irmin_unix.Resolver.Contents.term
 
 let hash = Irmin_unix.Resolver.Hash.term
 
-let store = Irmin_unix.Resolver.Store.term
+let store =
+  Irmin_unix.Resolver.Store.(add "pack" ~default:true (Variable_hash pack));
+  Irmin_unix.Resolver.Store.term
 
 let setup_log style_renderer level =
   Fmt_tty.setup_std_outputs ?style_renderer ();

--- a/src/irmin-server-types/cli.mli
+++ b/src/irmin-server-types/cli.mli
@@ -1,8 +1,6 @@
-val uri : string Cmdliner.Term.t
+val uri : Uri.t option Cmdliner.Term.t
 
-val contents : string option Cmdliner.Term.t
-
-val hash : Irmin_unix.Resolver.hash option Cmdliner.Term.t
+val default_uri : Uri.t
 
 val store :
   (string option * Irmin_unix.Resolver.hash option * string option)

--- a/src/irmin-server-types/cli.mli
+++ b/src/irmin-server-types/cli.mli
@@ -1,13 +1,11 @@
 val uri : string Cmdliner.Term.t
 
-val log_level : Logs.level Cmdliner.Term.t
-
 val contents : string option Cmdliner.Term.t
 
 val hash : Irmin_unix.Resolver.hash option Cmdliner.Term.t
 
-val default_contents : string
+val store :
+  (string option * Irmin_unix.Resolver.hash option * string option)
+  Cmdliner.Term.t
 
-val default_hash : Irmin_unix.Resolver.hash
-
-val store : Irmin_unix.Resolver.store Cmdliner.Term.t
+val setup_log : unit Cmdliner.Term.t

--- a/src/irmin-server-types/command.ml
+++ b/src/irmin-server-types/command.ml
@@ -200,7 +200,7 @@ module Make (St : Irmin.S) = struct
 
     module Commit_v = struct
       module Req = struct
-        type t = Irmin.Info.t * St.Hash.t list * Tree.t [@@deriving irmin]
+        type t = St.Info.t * St.Hash.t list * Tree.t [@@deriving irmin]
       end
 
       module Res = struct

--- a/src/irmin-server-types/command_intf.ml
+++ b/src/irmin-server-types/command_intf.ml
@@ -3,7 +3,11 @@ module type S = sig
 
   module Tree : Tree.S with module Private.Store = Store
 
-  module Commit : Commit.S with type hash = Store.Hash.t and type tree = Tree.t
+  module Commit :
+    Commit.S
+      with type hash = Store.Hash.t
+       and type tree = Tree.t
+       and module Info = Store.Info
 
   module Server_info : sig
     type t = { start_time : float }
@@ -84,7 +88,7 @@ module type S = sig
     (* Commit *)
     module Commit_v :
       CMD
-        with type Req.t = Irmin.Info.t * Store.hash list * Tree.t
+        with type Req.t = Store.Info.t * Store.hash list * Tree.t
          and type Res.t = Commit.t
 
     module Commit_of_hash :
@@ -107,32 +111,32 @@ module type S = sig
 
       module Set :
         CMD
-          with type Req.t = Store.key * Irmin.Info.t * Store.contents
+          with type Req.t = Store.key * Store.Info.t * Store.contents
            and type Res.t = unit
 
       module Test_and_set :
         CMD
           with type Req.t =
                 Store.key
-                * Irmin.Info.t
+                * Store.Info.t
                 * (Store.contents option * Store.contents option)
            and type Res.t = unit
 
       module Remove :
-        CMD with type Req.t = Store.key * Irmin.Info.t and type Res.t = unit
+        CMD with type Req.t = Store.key * Store.Info.t and type Res.t = unit
 
       module Find_tree :
         CMD with type Req.t = Store.key and type Res.t = Tree.t option
 
       module Set_tree :
         CMD
-          with type Req.t = Store.key * Irmin.Info.t * Tree.t
+          with type Req.t = Store.key * Store.Info.t * Tree.t
            and type Res.t = Tree.t
 
       module Test_and_set_tree :
         CMD
           with type Req.t =
-                Store.key * Irmin.Info.t * (Tree.t option * Tree.t option)
+                Store.key * Store.Info.t * (Tree.t option * Tree.t option)
            and type Res.t = Tree.t option
 
       module Mem : CMD with type Req.t = Store.key and type Res.t = bool
@@ -141,11 +145,11 @@ module type S = sig
 
       module Merge :
         CMD
-          with type Req.t = Irmin.Info.t * Store.Branch.t
+          with type Req.t = Store.Info.t * Store.Branch.t
            and type Res.t = unit
 
       module Merge_commit :
-        CMD with type Req.t = Irmin.Info.t * Commit.t and type Res.t = unit
+        CMD with type Req.t = Store.Info.t * Commit.t and type Res.t = unit
 
       module Last_modified :
         CMD with type Req.t = Store.key and type Res.t = Commit.t list

--- a/src/irmin-server-types/command_intf.ml
+++ b/src/irmin-server-types/command_intf.ml
@@ -1,7 +1,8 @@
 module type S = sig
   module Store : Irmin.S
 
-  module Tree : Tree.S with module Private.Store = Store
+  module Tree :
+    Tree.S with module Private.Store = Store and type Local.t = Store.tree
 
   module Commit :
     Commit.S
@@ -238,5 +239,9 @@ end
 module type Command = sig
   module type S = S
 
-  module Make (Store : Irmin.S) : S with module Store = Store
+  module Make (Store : Irmin.S) :
+    S
+      with module Store = Store
+       and module Tree.Private.Store = Store
+       and type Tree.Local.t = Store.tree
 end

--- a/src/irmin-server-types/command_store.ml
+++ b/src/irmin-server-types/command_store.ml
@@ -6,7 +6,10 @@ module Make
     (Tree : Tree.S
               with module Private.Store = Store
                and type Local.t = Store.tree)
-    (Commit : Commit.S with type hash = Store.hash and type tree = Tree.t) =
+    (Commit : Commit.S
+                with type hash = Store.hash
+                 and type tree = Tree.t
+                 and module Info = Store.Info) =
 struct
   include Context.Make (Store) (Tree)
 
@@ -35,7 +38,7 @@ struct
 
   module Set = struct
     module Req = struct
-      type t = Store.key * Irmin.Info.t * Store.contents [@@deriving irmin]
+      type t = Store.key * Store.Info.t * Store.contents [@@deriving irmin]
     end
 
     module Res = struct
@@ -53,7 +56,7 @@ struct
     module Req = struct
       type t =
         Store.key
-        * Irmin.Info.t
+        * Store.Info.t
         * (Store.contents option * Store.contents option)
       [@@deriving irmin]
     end
@@ -73,7 +76,7 @@ struct
 
   module Remove = struct
     module Req = struct
-      type t = Store.key * Irmin.Info.t [@@deriving irmin]
+      type t = Store.key * Store.Info.t [@@deriving irmin]
     end
 
     module Res = struct
@@ -106,7 +109,7 @@ struct
 
   module Set_tree = struct
     module Req = struct
-      type t = Store.key * Irmin.Info.t * Tree.t [@@deriving irmin]
+      type t = Store.key * Store.Info.t * Tree.t [@@deriving irmin]
     end
 
     module Res = struct
@@ -124,7 +127,7 @@ struct
 
   module Test_and_set_tree = struct
     module Req = struct
-      type t = Store.key * Irmin.Info.t * (Tree.t option * Tree.t option)
+      type t = Store.key * Store.Info.t * (Tree.t option * Tree.t option)
       [@@deriving irmin]
     end
 
@@ -193,7 +196,7 @@ struct
 
   module Merge = struct
     module Req = struct
-      type t = Irmin.Info.t * Store.Branch.t [@@deriving irmin]
+      type t = Store.Info.t * Store.Branch.t [@@deriving irmin]
     end
 
     module Res = struct
@@ -214,7 +217,7 @@ struct
 
   module Merge_commit = struct
     module Req = struct
-      type t = Irmin.Info.t * Commit.t [@@deriving irmin]
+      type t = Store.Info.t * Commit.t [@@deriving irmin]
     end
 
     module Res = struct

--- a/src/irmin-server-types/commit.ml
+++ b/src/irmin-server-types/commit.ml
@@ -9,7 +9,9 @@ module Make (St : Irmin.S) (T : Tree.S) = struct
 
   let hash_t = St.Hash.t
 
-  type t = { info : Irmin.Info.t; parents : hash list; hash : hash; tree : T.t }
+  module Info = St.Info
+
+  type t = { info : Info.t; parents : hash list; hash : hash; tree : T.t }
   [@@deriving irmin]
 
   let info { info; _ } = info

--- a/src/irmin-server-types/commit_intf.ml
+++ b/src/irmin-server-types/commit_intf.ml
@@ -7,15 +7,12 @@ module type S = sig
 
   val hash_t : hash Irmin.Type.t
 
-  type t = {
-    info : Irmin.Info.t;
-    parents : hash list;
-    hash : hash;
-    tree : tree;
-  }
+  module Info : Irmin.Info.S
+
+  type t = { info : Info.t; parents : hash list; hash : hash; tree : tree }
   [@@deriving irmin]
 
-  val info : t -> Irmin.Info.t
+  val info : t -> Info.t
 
   val hash : t -> hash
 
@@ -23,12 +20,12 @@ module type S = sig
 
   val tree : t -> tree
 
-  val v : info:Irmin.Info.t -> parents:hash list -> hash:hash -> tree:tree -> t
+  val v : info:Info.t -> parents:hash list -> hash:hash -> tree:tree -> t
 end
 
 module type Commit = sig
   module type S = S
 
   module Make (S : Irmin.S) (T : Tree.S) :
-    S with type hash = S.Hash.t and type tree = T.t
+    S with type hash = S.Hash.t and type tree = T.t and module Info = S.Info
 end

--- a/src/irmin-server-types/handshake.ml
+++ b/src/irmin-server-types/handshake.ml
@@ -1,13 +1,13 @@
 open Lwt.Syntax
 
 module V1 = struct
-  let s = "V1"
-
   let type_name x = Fmt.to_to_string Irmin.Type.pp_ty x
 
   let fingerprint (module Store : Irmin.S) : string =
-    let hash = Store.Hash.hash (fun f -> f s) in
-    Irmin.Type.to_string Store.Hash.t hash
+    let hex = Irmin.Type.to_string Store.Hash.t in
+    let contents_name = type_name Store.Contents.t in
+    let hash = Store.Hash.hash (fun f -> f contents_name) in
+    hex hash
 
   let send store ic oc =
     Lwt.catch

--- a/src/irmin-server-types/handshake.ml
+++ b/src/irmin-server-types/handshake.ml
@@ -18,6 +18,7 @@ module V1 = struct
       (function
         | Assert_failure _ | Lwt_unix.Timeout ->
             Error.raise_error "unable to connect to server"
+        | End_of_file -> Error.raise_error "invalid handshake"
         | x -> raise x)
 
   let check store ic oc =

--- a/src/irmin-server-types/tree.ml
+++ b/src/irmin-server-types/tree.ml
@@ -7,32 +7,35 @@ module Make (Store : Irmin.S) = struct
   end
 
   module Local = struct
-    type t = Store.tree
+    type t = Private.Store.tree
 
-    type key = Store.key
+    type key = Private.Store.key
 
-    type contents = Store.contents
+    type contents = Private.Store.contents
 
-    type node = Store.node
+    type node = Private.Store.node
 
-    type hash = Store.hash
+    type hash = Private.Store.hash
 
-    type step = Store.Key.step
+    type step = Private.Store.Key.step
 
-    type metadata = Store.metadata
+    type metadata = Private.Store.metadata
 
-    include Store.Tree
+    include Private.Store.Tree
 
-    let t = Store.tree_t
+    let t = Private.Store.tree_t
 
     let destruct x =
-      match Store.Tree.destruct x with
-      | `Contents (x, _) -> Lwt.return (`Contents (Store.Tree.Contents.hash x))
+      match Private.Store.Tree.destruct x with
+      | `Contents (x, _) ->
+          Lwt.return (`Contents (Private.Store.Tree.Contents.hash x))
       | `Node l ->
-          let+ l = list (Store.Tree.of_node l) Store.Key.empty in
+          let+ l =
+            list (Private.Store.Tree.of_node l) Private.Store.Key.empty
+          in
           `Node l
   end
 
-  type t = Hash of Store.Hash.t | ID of int | Local of Local.concrete
+  type t = Hash of Private.Store.Hash.t | ID of int | Local of Local.concrete
   [@@deriving irmin]
 end

--- a/src/irmin-server-types/tree_intf.ml
+++ b/src/irmin-server-types/tree_intf.ml
@@ -83,6 +83,7 @@ module type S = sig
        and type key = Store.key
        and type hash = Store.hash
        and type step = Store.Key.step
+       and type t = Store.tree
 
   type t = Hash of Store.Hash.t | ID of int | Local of Local.concrete
   [@@deriving irmin]
@@ -93,6 +94,5 @@ module type Tree = sig
 
   module type LOCAL = LOCAL
 
-  module Make (S : Irmin.S) :
-    S with module Private.Store = S and type Local.t = S.tree
+  module Make (S : Irmin.S) : S with module Private.Store = S
 end

--- a/src/irmin-server/server.ml
+++ b/src/irmin-server/server.ml
@@ -27,7 +27,6 @@ module Make (X : Command.S) = struct
   end)
 
   let v ?tls_config ~uri conf =
-    let uri = Uri.of_string uri in
     let scheme = Uri.scheme uri |> Option.value ~default:"tcp" in
     let* ctx, server =
       match String.lowercase_ascii scheme with

--- a/src/irmin-server/server_intf.ml
+++ b/src/irmin-server/server_intf.ml
@@ -9,7 +9,7 @@ module type S = sig
 
   val v :
     ?tls_config:[ `Cert_file of string ] * [ `Key_file of string ] ->
-    uri:string ->
+    uri:Uri.t ->
     Irmin.config ->
     t Lwt.t
   (** Create an instance of the server *)

--- a/test/util.ml
+++ b/test/util.ml
@@ -12,7 +12,7 @@ let test name f client _switch () =
 
 let run_server () =
   let path = Unix.getcwd () in
-  let uri = "unix://" ^ Filename.concat path "test.socket" in
+  let uri = Uri.of_string ("unix://" ^ Filename.concat path "test.socket") in
   let stop, wake = Lwt.wait () in
   Lwt.async (fun () ->
       let conf = Irmin_mem.config () in


### PR DESCRIPTION
Depends on https://github.com/mirage/irmin/pull/1413

- Use command line arguments from `irmin-unix` when possible. This also allows `irmin-server` to re-use any existing irmin config files.
- Allow store backend to be selected from the command line
- Add `Widget` type to help clean up dashboard implementation
- Show multiple previous updates on dashboard
- Update benchmark suite to match latest from irmin repo