### PR TITLE
Relax handshake: remove content type name from check

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -42,12 +42,12 @@ A handshake is performed when a client connects to the server
 
 The following is sent as a request from the client to server **AND** the response from server to client
 
-| Field              | Type                     |
-| -------            | ------------------------ |
-| contents type hash | `\n` delimited string    |
+| Field        | Type                     |
+| -------      | ------------------------ |
+| version hash | `\n` delimited string    |
 
-`contents hash type` is the hex-encoded hash of the **name** of the content type using `Store.Hash`.
+`version hash` is the hex-encoded hash of the current protocol version (`V1`) using `Store.Hash`.
 
-For example, for a store with `string` contents and BLAKE2B hash the `contents type hash` is equal to `BLAKE2B("string")`
+For example, for a store with BLAKE2B hash the `contents type hash` is equal to `BLAKE2B("V1")`
 
-This is used as a basic sanity check to ensure the client and server have the same hash and contents implementation
+This is used as a basic sanity check to ensure the client and server have the same hash implementation

--- a/src/irmin-server-types/handshake.ml
+++ b/src/irmin-server-types/handshake.ml
@@ -1,12 +1,13 @@
 open Lwt.Syntax
 
 module V1 = struct
+  let version = "V1"
+
   let type_name x = Fmt.to_to_string Irmin.Type.pp_ty x
 
   let fingerprint (module Store : Irmin.S) : string =
     let hex = Irmin.Type.to_string Store.Hash.t in
-    let contents_name = type_name Store.Contents.t in
-    let hash = Store.Hash.hash (fun f -> f contents_name) in
+    let hash = Store.Hash.hash (fun f -> f "V1") in
     hex hash
 
   let send store ic oc =


### PR DESCRIPTION
This will simplify writing clients and is mostly needed because types in other languages might not match up with the OCaml names, which will make using this interface strange.