### PR TITLE
Fix: Error when running server and typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ docker run --env PORT=9999 $(docker build -q .)
 For a list of available commands:
 
 ```shell
-$ dune exec bin/client/client/exe -- --help
+$ dune exec bin/client/client.exe -- --help
 ```
 
 For help with a specific command (for example, ping):

--- a/src/irmin-server-internal/cli.ml
+++ b/src/irmin-server-internal/cli.ml
@@ -25,6 +25,6 @@ let setup_log =
 
 let codec =
   let open Conn.Codec in
-  let doc = Arg.info ~doc:"Encoding to use for messages" [ "c"; "codec" ] in
+  let doc = Arg.info ~doc:"Encoding to use for messages" [ "codec" ] in
   let t = Arg.enum [ ("bin", (module Bin : S)); ("json", (module Json : S)) ] in
   Arg.(value & opt t (module Bin) doc)


### PR DESCRIPTION
Running this command - `dune exec bin/server/server.exe -- --root ./data` throws this error 
```
dune exec bin/server/server.exe -- --root ./data
Fatal error: exception (Invalid_argument
  "option name -c defined twice (doc strings are 'The type of user-defined contents (one of `string', `json' or `json-value'). Default is `string'.' and 'Encoding to use for messages')")
Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
Called from Stdlib__List.fold_left in file "list.ml", line 121, characters 24-34
Called from Cmdliner_cline.arg_info_indexes.loop in file "cmdliner_cline.ml", line 53, characters 23-54
Called from Cmdliner_cline.create in file "cmdliner_cline.ml", line 179, characters 27-46
Called from Cmdliner.Term.term_eval in file "cmdliner.ml", line 138, characters 20-56
Called from Cmdliner.Term.eval in file "cmdliner.ml", line 221, characters 18-44
Called from Dune__exe__Server in file "bin/server/server.ml", line 60, characters 15-42
```
[Patrick](https://patricoferris.com) gave this the fix and suggested a PR to fix the issue.

I also noticed a typo in the `README.md` file and added the correction as well