### PR TITLE
Abstract over IO

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,9 @@ jobs:
       - run: opam pin add irmin-server-internal.dev . --no-action
       - run: opam pin add irmin-server.dev . --no-action
       - run: opam pin add irmin-client.dev . --no-action
-      - run: "opam install irmin-server-internal irmin-server irmin-client --deps-only --with-doc --with-test || :"
+      - run: opam pin add irmin-client-unix.dev . --no-action
+      - run: "opam install irmin-server-internal irmin-server irmin-client irmin-client-unix --deps-only --with-doc --with-test || :"
       - run: opam install irmin irmin-pack
-      - run: opam exec -- dune build -p irmin-server-internal,irmin-server,irmin-client
-      - run: opam exec -- dune runtest -p irmin-server-internal,irmin-server,irmin-client
+      - run: opam exec -- dune build -p irmin-server-internal,irmin-server,irmin-client,irmin-client-unix
+      - run: opam exec -- dune runtest -p irmin-server-internal,irmin-server,irmin-client,irmin-client-unix
 

--- a/bin/client/client.ml
+++ b/bin/client/client.ml
@@ -40,7 +40,8 @@ let run f time iterations =
 
 let list_server_commands () =
   let module Store = Irmin_mem.KV.Make (Irmin.Contents.String) in
-  let module Cmd = Command.Make (Conn.Codec.Bin) (Store) in
+  let module Cmd = Command.Make (Irmin_client_unix.IO) (Conn.Codec.Bin) (Store)
+  in
   let str t =
     Fmt.to_to_string Irmin.Type.pp_ty t
     |> String.split_on_char '\n' |> String.concat "\n\t\t"
@@ -266,7 +267,7 @@ let config =
     let (module Store : Irmin.Generic_key.S) =
       Irmin_unix.Resolver.Store.generic_keyed store
     in
-    let module Client = Irmin_client.Make_ext (Codec) (Store) in
+    let module Client = Irmin_client_unix.Make_ext (Codec) (Store) in
     let uri =
       Irmin.Backend.Conf.(get config Irmin_http.Conf.Key.uri)
       |> Option.value ~default:Cli.default_uri

--- a/bin/client/dune
+++ b/bin/client/dune
@@ -2,4 +2,4 @@
  (public_name irmin-client)
  (package irmin-client-cli)
  (name client)
- (libraries irmin-client nottui-lwt irmin-unix))
+ (libraries irmin-client-unix nottui-lwt irmin-unix))

--- a/examples/branches.ml
+++ b/examples/branches.ml
@@ -1,7 +1,7 @@
 open Lwt.Syntax
 open Lwt.Infix
 module Store = Irmin_mem.KV.Make (Irmin.Contents.String)
-module Client = Irmin_client.Make (Store)
+module Client = Irmin_client_unix.Make (Store)
 module Error = Irmin_client.Error
 
 let main =

--- a/examples/dune
+++ b/examples/dune
@@ -1,13 +1,13 @@
 (executables
  (names server)
- (libraries irmin-server)
+ (libraries irmin.mem irmin-server)
  (modules server)
  (preprocess
   (pps ppx_irmin)))
 
 (executables
  (names ping tree branches)
- (libraries irmin-client-unix)
+ (libraries irmin.mem irmin-client-unix)
  (modules ping tree branches)
  (preprocess
   (pps ppx_irmin)))

--- a/examples/dune
+++ b/examples/dune
@@ -7,7 +7,7 @@
 
 (executables
  (names ping tree branches)
- (libraries irmin-client)
+ (libraries irmin-client-unix)
  (modules ping tree branches)
  (preprocess
   (pps ppx_irmin)))

--- a/examples/ping.ml
+++ b/examples/ping.ml
@@ -1,6 +1,6 @@
 open Lwt.Syntax
 module Store = Irmin_mem.KV.Make (Irmin.Contents.String)
-module Client = Irmin_client.Make (Store)
+module Client = Irmin_client_unix.Make (Store)
 
 let main =
   let uri = Uri.of_string "tcp://localhost:9090" in

--- a/examples/tree.ml
+++ b/examples/tree.ml
@@ -1,7 +1,7 @@
 open Lwt.Syntax
 open Lwt.Infix
 module Store = Irmin_mem.KV.Make (Irmin.Contents.String)
-module Client = Irmin_client.Make (Store)
+module Client = Irmin_client_unix.Make (Store)
 module Error = Irmin_client.Error
 
 let main =

--- a/irmin-client-unix.opam
+++ b/irmin-client-unix.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "A high-performance server for Irmin"
+synopsis: "A client for irmin-server"
 maintainer: "Zach Shipko <zachshipko@gmail.com>"
 authors: "Zach Shipko <zachshipko@gmail.com>"
 license: "ISC"
@@ -11,7 +11,6 @@ depends: [
   "dune" {>= "2.0.0"}
   "irmin-server-internal"
   "conduit-lwt-unix"
-  "alcotest-lwt" {with-test & >= "1.0.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/src/irmin-client-unix/IO.ml
+++ b/src/irmin-client-unix/IO.ml
@@ -1,0 +1,21 @@
+type flow = Conduit_lwt_unix.flow
+type ic = Conduit_lwt_unix.ic
+type oc = Conduit_lwt_unix.oc
+type ctx = Conduit_lwt_unix.ctx
+
+let default_ctx = Conduit_lwt_unix.default_ctx
+let is_closed (x : ic) = Lwt_io.is_closed x
+let write_int64_be = Lwt_io.BE.write_int64
+let read_int64_be = Lwt_io.BE.read_int64
+let flush = Lwt_io.flush
+let write = Lwt_io.write
+let read_into_exactly = Lwt_io.read_into_exactly
+let write_line = Lwt_io.write_line
+let read_line = Lwt_io.read_line
+let write_char = Lwt_io.write_char
+let read_char = Lwt_io.read_char
+
+let connect ~ctx (client : Irmin_client.addr) =
+  Conduit_lwt_unix.connect ~ctx (client :> Conduit_lwt_unix.client)
+
+let close (c : ic * oc) = Conduit_lwt_server.close c

--- a/src/irmin-client-unix/dune
+++ b/src/irmin-client-unix/dune
@@ -1,0 +1,4 @@
+(library
+ (name irmin_client_unix)
+ (public_name irmin-client-unix)
+ (libraries irmin-client conduit-lwt-unix))

--- a/src/irmin-client-unix/irmin_client_unix.ml
+++ b/src/irmin-client-unix/irmin_client_unix.ml
@@ -1,11 +1,12 @@
-include Irmin_server_intf
 open Irmin_server_internal
 module Error = Error
+module IO = IO
 
-module type S = Server.S
-
-module Make_ext (Codec : Conn.Codec.S) (Store : Irmin.Generic_key.S) = struct
-  include Server.Make (Codec) (Store)
+module Make_ext
+    (Codec : Irmin_server_internal.Conn.Codec.S)
+    (Store : Irmin.Generic_key.S) =
+struct
+  include Irmin_client.Make_ext (IO) (Codec) (Store)
 end
 
 module Make (Store : Irmin.Generic_key.S) = Make_ext (Conn.Codec.Bin) (Store)

--- a/src/irmin-client-unix/irmin_client_unix.mli
+++ b/src/irmin-client-unix/irmin_client_unix.mli
@@ -1,0 +1,43 @@
+module Error = Irmin_client.Error
+module IO : Irmin_client.Client.IO
+
+module Make_ext
+    (Codec : Irmin_server_internal.Conn.Codec.S)
+    (Store : Irmin.Generic_key.S) :
+  Irmin_client.S
+    with type hash = Store.hash
+     and type contents = Store.contents
+     and type branch = Store.branch
+     and type path = Store.path
+     and type step = Store.step
+     and type metadata = Store.metadata
+     and type slice = Store.slice
+     and module Schema = Store.Schema
+     and type Private.Store.tree = Store.tree
+     and module IO = IO
+
+module Make (Store : Irmin.Generic_key.S) :
+  Irmin_client.S
+    with type hash = Store.hash
+     and type contents = Store.contents
+     and type branch = Store.branch
+     and type path = Store.path
+     and type step = Store.step
+     and type metadata = Store.metadata
+     and type slice = Store.slice
+     and module Schema = Store.Schema
+     and type Private.Store.tree = Store.tree
+     and module IO = IO
+
+module Make_json (Store : Irmin.Generic_key.S) :
+  Irmin_client.S
+    with type hash = Store.hash
+     and type contents = Store.contents
+     and type branch = Store.branch
+     and type path = Store.path
+     and type step = Store.step
+     and type metadata = Store.metadata
+     and type slice = Store.slice
+     and module Schema = Store.Schema
+     and type Private.Store.tree = Store.tree
+     and module IO = IO

--- a/src/irmin-client/dune
+++ b/src/irmin-client/dune
@@ -1,4 +1,4 @@
 (library
  (name irmin_client)
  (public_name irmin-client)
- (libraries irmin-server-internal))
+ (libraries irmin-server-internal ipaddr))

--- a/src/irmin-client/irmin_client.ml
+++ b/src/irmin-client/irmin_client.ml
@@ -5,19 +5,18 @@ module type S = Client.S
 
 module Client = Client
 
+type addr = Client_intf.addr
+
 module Make_ext
+    (IO : Client.IO)
     (Codec : Irmin_server_internal.Conn.Codec.S)
     (Store : Irmin.Generic_key.S) =
 struct
-  module Command = struct
-    include Command
-    include Command.Make (Codec) (Store)
-  end
-
-  include Client.Make (Command)
+  include Client.Make (IO) (Codec) (Store)
 end
 
-module Make (Store : Irmin.Generic_key.S) = Make_ext (Conn.Codec.Bin) (Store)
+module Make (IO : Client.IO) (Store : Irmin.Generic_key.S) =
+  Make_ext (IO) (Conn.Codec.Bin) (Store)
 
-module Make_json (Store : Irmin.Generic_key.S) =
-  Make_ext (Conn.Codec.Json) (Store)
+module Make_json (IO : Client.IO) (Store : Irmin.Generic_key.S) =
+  Make_ext (IO) (Conn.Codec.Json) (Store)

--- a/src/irmin-client/irmin_client_intf.ml
+++ b/src/irmin-client/irmin_client_intf.ml
@@ -7,19 +7,12 @@ module type Irmin_client = sig
   module Error = Error
   module Client = Client
 
-  module Make_ext (Codec : Conn.Codec.S) (Store : Irmin.Generic_key.S) :
-    S
-      with type hash = Store.hash
-       and type contents = Store.contents
-       and type branch = Store.branch
-       and type path = Store.path
-       and type step = Store.step
-       and type metadata = Store.metadata
-       and type slice = Store.slice
-       and module Schema = Store.Schema
-       and type Private.Store.tree = Store.tree
+  type addr = Client.addr
 
-  module Make (Store : Irmin.Generic_key.S) :
+  module Make_ext
+      (IO : Client.IO)
+      (Codec : Conn.Codec.S)
+      (Store : Irmin.Generic_key.S) :
     S
       with type hash = Store.hash
        and type contents = Store.contents
@@ -30,8 +23,9 @@ module type Irmin_client = sig
        and type slice = Store.slice
        and module Schema = Store.Schema
        and type Private.Store.tree = Store.tree
+       and module IO = IO
 
-  module Make_json (Store : Irmin.Generic_key.S) :
+  module Make (IO : Client.IO) (Store : Irmin.Generic_key.S) :
     S
       with type hash = Store.hash
        and type contents = Store.contents
@@ -42,4 +36,18 @@ module type Irmin_client = sig
        and type slice = Store.slice
        and module Schema = Store.Schema
        and type Private.Store.tree = Store.tree
+       and module IO = IO
+
+  module Make_json (IO : Client.IO) (Store : Irmin.Generic_key.S) :
+    S
+      with type hash = Store.hash
+       and type contents = Store.contents
+       and type branch = Store.branch
+       and type path = Store.path
+       and type step = Store.step
+       and type metadata = Store.metadata
+       and type slice = Store.slice
+       and module Schema = Store.Schema
+       and type Private.Store.tree = Store.tree
+       and module IO = IO
 end

--- a/src/irmin-server-internal/command.ml
+++ b/src/irmin-server-internal/command.ml
@@ -2,11 +2,12 @@ open Lwt.Syntax
 open Lwt.Infix
 include Command_intf
 
-module Make (Codec : Conn.Codec.S) (St : Irmin.Generic_key.S) = struct
+module Make (IO : Conn.IO) (Codec : Conn.Codec.S) (St : Irmin.Generic_key.S) =
+struct
   module Store = St
   module Tree = Tree.Make (St)
   module Commit = Commit.Make (St) (Tree)
-  include Context.Make (Codec) (St) (Tree)
+  include Context.Make (IO) (Codec) (St) (Tree)
   module Return = Conn.Return
 
   type t = (module CMD)
@@ -412,8 +413,8 @@ module Make (Codec : Conn.Codec.S) (St : Irmin.Generic_key.S) = struct
         Return.v conn Res.t ()
     end
 
-    module Store = Command_store.Make (Codec) (St) (Tree) (Commit)
-    module Tree = Command_tree.Make (Codec) (St) (Tree) (Commit)
+    module Store = Command_store.Make (IO) (Codec) (St) (Tree) (Commit)
+    module Tree = Command_tree.Make (IO) (Codec) (St) (Tree) (Commit)
   end
 
   let commands : (string * (module CMD)) list =

--- a/src/irmin-server-internal/command_intf.ml
+++ b/src/irmin-server-internal/command_intf.ml
@@ -317,9 +317,13 @@ end
 module type Command = sig
   module type S = S
 
-  module Make (Codec : Conn.Codec.S) (Store : Irmin.Generic_key.S) :
+  module Make
+      (IO : Conn.IO)
+      (Codec : Conn.Codec.S)
+      (Store : Irmin.Generic_key.S) :
     S
       with module Store = Store
        and module Tree.Private.Store = Store
        and type Tree.Local.t = Store.tree
+       and module Conn.IO = IO
 end

--- a/src/irmin-server-internal/command_store.ml
+++ b/src/irmin-server-internal/command_store.ml
@@ -2,6 +2,7 @@ open Lwt.Syntax
 open Lwt.Infix
 
 module Make
+    (IO : Conn.IO)
     (Codec : Conn.Codec.S)
     (Store : Irmin.Generic_key.S)
     (Tree : Tree.S
@@ -13,7 +14,7 @@ module Make
                  and type key = Store.commit_key
                  and module Info = Store.Info) =
 struct
-  include Context.Make (Codec) (Store) (Tree)
+  include Context.Make (IO) (Codec) (Store) (Tree)
   module Return = Conn.Return
 
   let convert_commit head =

--- a/src/irmin-server-internal/command_tree.ml
+++ b/src/irmin-server-internal/command_tree.ml
@@ -1,6 +1,7 @@
 open Lwt.Syntax
 
 module Make
+    (IO : Conn.IO)
     (Codec : Conn.Codec.S)
     (Store : Irmin.Generic_key.S)
     (Tree : Tree.S
@@ -8,7 +9,7 @@ module Make
                and type Local.t = Store.tree)
     (Commit : Commit.S with type hash = Store.hash and type tree = Tree.t) =
 struct
-  include Context.Make (Codec) (Store) (Tree)
+  include Context.Make (IO) (Codec) (Store) (Tree)
   module Return = Conn.Return
 
   module Empty = struct

--- a/src/irmin-server-internal/conn_intf.ml
+++ b/src/irmin-server-internal/conn_intf.ml
@@ -5,23 +5,30 @@ module Codec = struct
   end
 end
 
-type t = {
-  flow : Conduit_lwt_unix.flow;
-  ic : Conduit_lwt_unix.ic;
-  oc : Conduit_lwt_unix.oc;
-  buffer : bytes;
-}
+module type IO = sig
+  type flow
+  type ic
+  type oc
+
+  val is_closed : ic -> bool
+  val write_int64_be : oc -> int64 -> unit Lwt.t
+  val read_int64_be : ic -> int64 Lwt.t
+  val flush : oc -> unit Lwt.t
+  val write : oc -> string -> unit Lwt.t
+  val read_into_exactly : ic -> bytes -> int -> int -> unit Lwt.t
+  val write_line : oc -> string -> unit Lwt.t
+  val read_line : ic -> string Lwt.t
+  val write_char : oc -> char -> unit Lwt.t
+  val read_char : ic -> char Lwt.t
+end
 
 module type S = sig
-  type nonrec t = t
+  module IO : IO
 
-  val v :
-    ?buffer_size:int ->
-    Conduit_lwt_unix.flow ->
-    Conduit_lwt_unix.ic ->
-    Conduit_lwt_unix.oc ->
-    t
-  (** Create a new connection using [flow], [ic] and [oc] from conduit *)
+  type t = { flow : IO.flow; ic : IO.ic; oc : IO.oc; buffer : bytes }
+
+  val v : ?buffer_size:int -> IO.flow -> IO.ic -> IO.oc -> t
+  (** Create a new connection using [flow], [ic] and [oc] *)
 
   val is_closed : t -> bool
   (** Check if the underlying channel is closed *)
@@ -82,8 +89,6 @@ module type S = sig
 end
 
 module type Sigs = sig
-  type nonrec t = t
-
   module Codec : sig
     module type S = Codec.S
 
@@ -92,6 +97,7 @@ module type Sigs = sig
   end
 
   module type S = S
+  module type IO = IO
 
-  module Make (C : Codec.S) : S
+  module Make (IO : IO) (C : Codec.S) : S with module IO = IO
 end

--- a/src/irmin-server-internal/context.ml
+++ b/src/irmin-server-internal/context.ml
@@ -2,6 +2,7 @@ open Lwt.Syntax
 open Lwt.Infix
 
 module Make
+    (IO : Conn.IO)
     (Codec : Conn.Codec.S)
     (St : Irmin.Generic_key.S)
     (Tree : Tree.S with module Private.Store = St and type Local.t = St.tree) =
@@ -12,7 +13,7 @@ struct
     let uptime { start_time; _ } = Unix.time () -. start_time
   end
 
-  module Conn = Conn.Make (Codec)
+  module Conn = Conn.Make (IO) (Codec)
 
   type context = {
     conn : Conn.t;

--- a/src/irmin-server-internal/dune
+++ b/src/irmin-server-internal/dune
@@ -1,6 +1,6 @@
 (library
  (name irmin_server_internal)
  (public_name irmin-server-internal)
- (libraries irmin irmin-pack conduit-lwt-unix)
+ (libraries irmin irmin-pack)
  (preprocess
   (pps ppx_irmin)))

--- a/src/irmin-server/IO.ml
+++ b/src/irmin-server/IO.ml
@@ -1,0 +1,14 @@
+type flow = Conduit_lwt_unix.flow
+type ic = Conduit_lwt_unix.ic
+type oc = Conduit_lwt_unix.oc
+
+let is_closed (x : ic) = Lwt_io.is_closed x
+let write_int64_be = Lwt_io.BE.write_int64
+let read_int64_be = Lwt_io.BE.read_int64
+let flush = Lwt_io.flush
+let write = Lwt_io.write
+let read_into_exactly = Lwt_io.read_into_exactly
+let write_line = Lwt_io.write_line
+let read_line = Lwt_io.read_line
+let write_char = Lwt_io.write_char
+let read_char = Lwt_io.read_char

--- a/src/irmin-server/dune
+++ b/src/irmin-server/dune
@@ -1,4 +1,4 @@
 (library
  (name irmin_server)
  (public_name irmin-server)
- (libraries irmin-server-internal))
+ (libraries irmin-server-internal conduit-lwt-unix))

--- a/src/irmin-server/server_intf.ml
+++ b/src/irmin-server/server_intf.ml
@@ -25,5 +25,6 @@ end
 module type Server = sig
   module type S = S
 
-  module Make (C : Command.S) : S with module Store = C.Store
+  module Make (Codec : Conn.Codec.S) (Store : Irmin.Generic_key.S) :
+    S with module Store = Store and module Command.Conn.IO = IO
 end

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries irmin-server irmin-client-unix alcotest-lwt))
+ (libraries irmin.mem irmin-server irmin-client-unix alcotest-lwt))

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
  (name test)
- (libraries irmin-server irmin-client alcotest-lwt))
+ (libraries irmin-server irmin-client-unix alcotest-lwt))

--- a/test/util.ml
+++ b/test/util.ml
@@ -3,7 +3,7 @@ open Lwt.Infix
 module Rpc = struct
   module Codec = Irmin_server_internal.Conn.Codec.Bin
   module Store = Irmin_mem.KV.Make (Irmin.Contents.String)
-  module Client = Irmin_client.Make_ext (Codec) (Store)
+  module Client = Irmin_client_unix.Make_ext (Codec) (Store)
   module Server = Irmin_server.Make_ext (Codec) (Store)
 end
 


### PR DESCRIPTION
Since `irmin-client` and `irmin-server` depend directly on `irmin` it's not really possible to remove the `Lwt` dependency, however allowing the user to provide their own I/O functions removes the `conduit-lwt-unix` requirement.