### PR TITLE
Improve handshake

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -17,8 +17,7 @@ A request is sent from the client to the server
 
 | Field               | Type                        |
 | ------------------- | --------------------------- |
-| command             | `\n` delimited string       |
-| '\n'                | Extra '\n' character        |
+| command             | `\n\n` delimited string     |
 | request             | Message                     |
 
 ## Response
@@ -48,8 +47,9 @@ The following is sent as a request from the client to server **AND** the respons
 | -------      | ------------------------- |
 | version hash | `\n` delimited string     |
 
-`version hash` is the hex-encoded hash of the current protocol version (`V1`) using `Store.Hash`.
+`contents type hash` is the protocol version appended to the hex-encoded hash of the name of the store contents type using `Store.Hash`. The name of the content type is determined by `Irmin.Type.pp_ty`.
 
-For example, for a store with BLAKE2B hash the `contents type hash` is equal to `BLAKE2B("V1")`
+For example, for a store with BLAKE2B hash and string contents the `contents type hash` is equal to `V1 + BLAKE2B("Custom (string)")`
 
-This is used as a basic sanity check to ensure the client and server have the same hash implementation
+This is used as a basic sanity check to ensure the client and server have the same hash and contents.
+

--- a/bin/server/server.ml
+++ b/bin/server/server.ml
@@ -14,7 +14,7 @@ let setup_log =
     const setup_log $ Fmt_cli.style_renderer () $ Logs_cli.level ())
 
 let main ~readonly ~root ~uri ~tls ~store ~contents ~hash ~config_path
-    (module Codec : Conn.Codec.S) =
+    (module Codec : Conn.Codec.S) fingerprint =
   let store, config =
     Irmin_unix.Resolver.load_config ?root ?config_path ?store ?hash ?contents ()
   in
@@ -25,20 +25,28 @@ let main ~readonly ~root ~uri ~tls ~store ~contents ~hash ~config_path
     Irmin_unix.Resolver.Store.generic_keyed store
   in
   let module Server = Irmin_server.Make_ext (Codec) (Store) in
-  let tls_config =
-    match tls with Some (c, k) -> Some (`Cert_file c, `Key_file k) | _ -> None
-  in
-  let uri =
-    Irmin.Backend.Conf.(get config Irmin_http.Conf.Key.uri)
-    |> Option.value ~default:Cli.default_uri
-  in
-  let config = if readonly then Server.readonly config else config in
-  let* server = Server.v ?tls_config ~uri config in
-  let root = match root with Some root -> root | None -> "" in
-  Logs.app (fun l -> l "Listening on %a, store: %s" Uri.pp_hum uri root);
-  Server.serve server
+  if fingerprint then
+    Lwt_io.printl
+    @@ Server.Command.Conn.Handshake.V1.fingerprint
+         (module Store : Irmin.Generic_key.S)
+  else
+    let tls_config =
+      match tls with
+      | Some (c, k) -> Some (`Cert_file c, `Key_file k)
+      | _ -> None
+    in
+    let uri =
+      Irmin.Backend.Conf.(get config Irmin_http.Conf.Key.uri)
+      |> Option.value ~default:Cli.default_uri
+    in
+    let config = if readonly then Server.readonly config else config in
+    let* server = Server.v ?tls_config ~uri config in
+    let root = match root with Some root -> root | None -> "" in
+    Logs.app (fun l -> l "Listening on %a, store: %s" Uri.pp_hum uri root);
+    Server.serve server
 
-let main readonly root uri tls (store, hash, contents) codec config_path () =
+let main readonly root uri tls (store, hash, contents) codec config_path
+    fingerprint () =
   let codec =
     match codec with
     | `Bin -> (module Conn.Codec.Bin : Conn.Codec.S)
@@ -46,6 +54,7 @@ let main readonly root uri tls (store, hash, contents) codec config_path () =
   in
   Lwt_main.run
   @@ main ~readonly ~root ~uri ~tls ~store ~contents ~hash ~config_path codec
+       fingerprint
 
 open Cmdliner
 
@@ -70,11 +79,17 @@ let tls =
   in
   Arg.(value @@ opt (some (pair string string)) None doc)
 
+let fingerprint =
+  let doc =
+    Arg.info ~docs:"" ~doc:"Print handshake fingerprint" [ "fingerprint" ]
+  in
+  Arg.(value @@ flag doc)
+
 let main_term =
   Term.(
     const main $ readonly $ root $ Cli.uri $ tls
     $ Irmin_unix.Resolver.Store.term ()
-    $ Cli.codec $ Cli.config_path $ setup_log)
+    $ Cli.codec $ Cli.config_path $ fingerprint $ setup_log)
 
 let[@alert "-deprecated"] () =
   let info = Term.info "irmin-server" in

--- a/src/irmin-client/client.ml
+++ b/src/irmin-client/client.ml
@@ -10,7 +10,8 @@ module Conf = struct
   let uri = Irmin.Type.(map string) Uri.of_string Uri.to_string
 
   let uri =
-    Irmin.Backend.Conf.key ~spec "uri" uri (Uri.of_string "127.0.0.1:9181")
+    Irmin.Backend.Conf.key ~spec "uri" uri
+      (Uri.of_string "tcp://127.0.0.1:9181")
 
   let batch_size = Irmin.Backend.Conf.key ~spec "client" Irmin.Type.int 32
   let tls = Irmin.Backend.Conf.key ~spec "tls" Irmin.Type.bool false

--- a/src/irmin-server-internal/conn_intf.ml
+++ b/src/irmin-server-internal/conn_intf.ml
@@ -52,6 +52,7 @@ module type S = sig
   module Handshake : sig
     module V1 : sig
       val version : string
+      val fingerprint : (module Irmin.Generic_key.S) -> string
       val send : (module Irmin.Generic_key.S) -> t -> bool Lwt.t
       val check : (module Irmin.Generic_key.S) -> t -> bool Lwt.t
     end

--- a/src/irmin-server-internal/conn_intf.ml
+++ b/src/irmin-server-internal/conn_intf.ml
@@ -52,7 +52,7 @@ module type S = sig
   module Handshake : sig
     module V1 : sig
       val version : string
-      val send : (module Irmin.Generic_key.S) -> t -> unit Lwt.t
+      val send : (module Irmin.Generic_key.S) -> t -> bool Lwt.t
       val check : (module Irmin.Generic_key.S) -> t -> bool Lwt.t
     end
   end


### PR DESCRIPTION
- Make handshake more strict by incorporating content type name in hash
- Add `irmin-server --fingerprint` to show the expected fingerprint for a server