### PR TITLE
Fix browser websockets

### DIFF
--- a/src/irmin-server/server.ml
+++ b/src/irmin-server/server.ml
@@ -260,6 +260,7 @@ module Make (Codec : Conn.Codec.S) (Store : Irmin.Generic_key.S) = struct
       match Uri.scheme t.uri with
       | Some "ws" | Some "wss" ->
           Websocket_lwt_unix.establish_standard_server ~ctx:t.ctx ~mode:t.server
+            ~on_exn
             ~check_request:(fun _ -> true)
             (websocket_handler t)
       | _ ->


### PR DESCRIPTION
This is partially related to #50 -- the patches to get `irmin-test` in the browser will take some time to upstream probably (if at all desired by the the irmin folk), but I did manage to get it running to test the websocket backend in the browser. The main problem was the growing of the buffer, which was wrong.

I also took the liberty of catching any errors in the webwocket creation in the browser, previously we would just end up stuck on a promise that never resolves. At the moment, the `irmin-test` suite doesn't pass in Chrome but does in Safari. Chrome is closing sockets with code `1006` -- I think this might be some kind of security feature because we open lots of connections which is a little annoying.

cc @dinakajoy 