### PR TITLE
Sync remote store into local store

### DIFF
--- a/examples/sync.ml
+++ b/examples/sync.ml
@@ -1,24 +1,30 @@
 open Lwt.Syntax
 module Store = Irmin_mem.KV.Make (Irmin.Contents.String)
 module Client = Irmin_client_unix.Make (Store)
-module Sync = Irmin.Sync.Make (Client)
+module Sync = Irmin.Sync.Make (Store)
 
 let main =
   let uri = Utils.get_url in
   let* client = Client.connect uri in
   let* main = Client.main client in
+  let* repo = Store.Repo.v (Irmin_mem.config ()) in
+  let* local_main = Store.main repo in
   let* res = Client.ping client in
   match res with
   | Ok () -> (
       let* status =
-        Sync.pull_exn main (Irmin.Sync.remote_store (module Client) main) `Set
+        Sync.pull_exn local_main
+          (Irmin.Sync.remote_store (module Client) main)
+          `Set
       in
       match status with
       | `Empty ->
           Fmt.pr "Synced returned empty";
           Lwt.return_unit
       | `Head commit ->
-          Fmt.pr "Synced: %a" Client.Commit.pp_hash commit;
+          Fmt.pr "Synced: %a\n" Store.Commit.pp_hash commit;
+          let* lst = Store.list local_main [] in
+          Fmt.pr "Keys: %a\n" Fmt.(list string) (List.map fst lst);
           Lwt.return_unit)
   | Error e ->
       Fmt.pr "ERROR: %s\n" (Irmin_client.Error.to_string e);


### PR DESCRIPTION
I think this PR improves the `sync.ml` example. It actually now has the behaviour I thought my original PR had i.e. using `irmin-client` to sync a store into the local one.

cc: @dinakajoy 