### PR TITLE
Update to irmin#main

### DIFF
--- a/bin/client/client.ml
+++ b/bin/client/client.ml
@@ -264,13 +264,13 @@ let config =
     in
     let (module Codec) = codec in
     let store, config =
-      Irmin_unix.Resolver.load_config ?config_path ?store ?hash ?contents ()
+      Irmin_cli.Resolver.load_config ?config_path ?store ?hash ?contents ()
     in
     let config =
       match uri with Some uri -> Irmin_http.config uri config | None -> config
     in
     let (module Store : Irmin.Generic_key.S) =
-      Irmin_unix.Resolver.Store.generic_keyed store
+      Irmin_cli.Resolver.Store.generic_keyed store
     in
     let module Client = Irmin_client_unix.Make_codec (Codec) (Store) in
     let uri =
@@ -281,7 +281,7 @@ let config =
   in
   Term.(
     const create $ Cli.uri $ branch $ tls
-    $ Irmin_unix.Resolver.Store.term ()
+    $ Irmin_cli.Resolver.Store.term ()
     $ Cli.codec $ Cli.config_path $ setup_log)
 
 let help =

--- a/bin/client/dune
+++ b/bin/client/dune
@@ -2,4 +2,4 @@
  (public_name irmin-client)
  (package irmin-client-cli)
  (name client)
- (libraries irmin-client-unix irmin-unix fmt.cli logs.cli fmt.tty))
+ (libraries irmin-client-unix irmin-cli fmt.cli logs.cli fmt.tty))

--- a/bin/server/dune
+++ b/bin/server/dune
@@ -2,4 +2,4 @@
  (public_name irmin-server)
  (package irmin-server-cli)
  (name server)
- (libraries irmin-server irmin-unix fmt.cli logs.cli fmt.tty))
+ (libraries irmin-server irmin.unix irmin-cli fmt.cli logs.cli fmt.tty))

--- a/bin/server/server.ml
+++ b/bin/server/server.ml
@@ -16,13 +16,13 @@ let setup_log =
 let main ~readonly ~root ~uri ~tls ~store ~contents ~hash ~config_path
     (module Codec : Conn.Codec.S) fingerprint =
   let store, config =
-    Irmin_unix.Resolver.load_config ?root ?config_path ?store ?hash ?contents ()
+    Irmin_cli.Resolver.load_config ?root ?config_path ?store ?hash ?contents ()
   in
   let config =
     match uri with Some uri -> Irmin_http.config uri config | None -> config
   in
   let (module Store : Irmin.Generic_key.S) =
-    Irmin_unix.Resolver.Store.generic_keyed store
+    Irmin_cli.Resolver.Store.generic_keyed store
   in
   let module Server = Irmin_server.Make_ext (Codec) (Store) in
   if fingerprint then
@@ -88,7 +88,7 @@ let fingerprint =
 let main_term =
   Term.(
     const main $ readonly $ root $ Cli.uri $ tls
-    $ Irmin_unix.Resolver.Store.term ()
+    $ Irmin_cli.Resolver.Store.term ()
     $ Cli.codec $ Cli.config_path $ fingerprint $ setup_log)
 
 let[@alert "-deprecated"] () =

--- a/irmin-client-cli.opam
+++ b/irmin-client-cli.opam
@@ -10,21 +10,19 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
   "irmin-client" {= version}
-  "irmin-unix" {>= "dev"}
+  "irmin-cli" {>= "dev"}
 ]
 pin-depends: [
-  ["graphql.dev" "git+https://github.com/zshipko/ocaml-graphql-server#b2be4daeca46005ddbe79f6e8a38a9c272af0fb5"]
-  ["graphql-cohttp.dev" "git+https://github.com/zshipko/ocaml-graphql-server#b2be4daeca46005ddbe79f6e8a38a9c272af0fb5"]
-  ["irmin-graphql.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-unix.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-pack.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-git.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-fs.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-http.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-tezos.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-test.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["ppx_irmin.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
+  ["irmin-graphql.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-unix.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-pack.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-git.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-fs.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-http.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-tezos.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-test.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["ppx_irmin.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/irmin-client-cli.opam
+++ b/irmin-client-cli.opam
@@ -14,7 +14,7 @@ depends: [
 ]
 pin-depends: [
   ["irmin-graphql.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
-  ["irmin-unix.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-cli.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
   ["irmin.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
   ["irmin-pack.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
   ["irmin-git.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]

--- a/irmin-server-cli.opam
+++ b/irmin-server-cli.opam
@@ -14,7 +14,7 @@ depends: [
 ]
 pin-depends: [
   ["irmin-graphql.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
-  ["irmin-unix.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-cli.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
   ["irmin.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
   ["irmin-pack.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
   ["irmin-git.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]

--- a/irmin-server-cli.opam
+++ b/irmin-server-cli.opam
@@ -10,21 +10,19 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
   "irmin-server" {= version}
-  "irmin-unix" {>= "dev"}
+  "irmin-cli" {>= "dev"}
 ]
 pin-depends: [
-  ["graphql.dev" "git+https://github.com/zshipko/ocaml-graphql-server#b2be4daeca46005ddbe79f6e8a38a9c272af0fb5"]
-  ["graphql-cohttp.dev" "git+https://github.com/zshipko/ocaml-graphql-server#b2be4daeca46005ddbe79f6e8a38a9c272af0fb5"]
-  ["irmin-graphql.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-unix.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-pack.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-git.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-fs.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-http.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-tezos.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-test.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["ppx_irmin.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
+  ["irmin-graphql.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-unix.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-pack.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-git.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-fs.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-http.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-tezos.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-test.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["ppx_irmin.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/irmin-server-internal.opam
+++ b/irmin-server-internal.opam
@@ -21,8 +21,8 @@ depends: [
   "ppx_irmin" {>= "dev"}
 ]
 pin-depends: [
-  ["irmin.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["ppx_irmin.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
+  ["irmin.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["ppx_irmin.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/irmin-server.opam
+++ b/irmin-server.opam
@@ -20,7 +20,7 @@ depends: [
 ]
 pin-depends: [
   ["irmin-graphql.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
-  ["irmin-unix.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-cli.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
   ["irmin.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
   ["irmin-pack.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
   ["irmin-git.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]

--- a/irmin-server.opam
+++ b/irmin-server.opam
@@ -13,24 +13,22 @@ depends: [
   "conduit-lwt-unix"
   "irmin-pack"
   "alcotest-lwt" {with-test & >= "1.0.0"}
-  "irmin-unix" {with-test}
+  "irmin-cli" {with-test}
   "irmin-test" {with-test}
   "irmin-client-unix" {with-test}
   "websocket-lwt-unix"
 ]
 pin-depends: [
-  ["graphql.dev" "git+https://github.com/zshipko/ocaml-graphql-server#b2be4daeca46005ddbe79f6e8a38a9c272af0fb5"]
-  ["graphql-cohttp.dev" "git+https://github.com/zshipko/ocaml-graphql-server#b2be4daeca46005ddbe79f6e8a38a9c272af0fb5"]
-  ["irmin-graphql.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-unix.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-pack.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-git.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-fs.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-http.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-tezos.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["irmin-test.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
-  ["ppx_irmin.dev" "git+https://github.com/patricoferris/irmin#5876116b6c468ce2a4a94e112257bc71f8288cb1"]
+  ["irmin-graphql.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-unix.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-pack.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-git.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-fs.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-http.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-tezos.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["irmin-test.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
+  ["ppx_irmin.dev" "git+https://github.com/mirage/irmin#3b18b671889fdbd1c8d1b2510dd48c55f3f29744"]
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/test/test.ml
+++ b/test/test.ml
@@ -69,10 +69,7 @@ let ping () =
   Logs.debug (fun l -> l "AFTER PING");
   Alcotest.(check (result unit error)) "ping" (Ok ()) r
 
-let misc =
-  let run f () = Lwt_main.run (f ()) in
-  [ ("ping", `Quick, run ping) ]
-
+let misc = [ ("ping", `Quick, ping) ]
 let misc = [ ("misc", misc) ]
 
 let () =
@@ -91,4 +88,5 @@ let () =
           (`Quick, Websocket.suite);
         ]
   in
-  Irmin_test.Store.run "irmin-server" ~slow ~misc tests
+  Lwt_main.run
+    (Irmin_test.Store.run "irmin-server" ~sleep:Lwt_unix.sleep ~slow ~misc tests)


### PR DESCRIPTION
Now that irmin is using graphql.0.14.0 we can start tracking irmin#main again